### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,5 +1,8 @@
 name: PR Build Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/sagniKdas53/yt-diff-react/security/code-scanning/2](https://github.com/sagniKdas53/yt-diff-react/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block for the workflow or the specific job to limit the `GITHUB_TOKEN` to the minimum necessary scopes. Since this workflow only checks out code, installs dependencies, and runs lint/build locally, it only needs read access to repository contents (and no write access).

The best minimal fix without changing functionality is to add a root-level `permissions` block immediately after the workflow `name:` line (or before `jobs:`). This will apply to all jobs in this workflow. The recommended value is:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or other definitions are needed; this is purely a YAML configuration change within `.github/workflows/pr-build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
