### PR TITLE
Renew the session token on wake instead of minting month-long ones (F7)

### DIFF
--- a/src/AppProviders.jsx
+++ b/src/AppProviders.jsx
@@ -3,6 +3,20 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { NotificationProvider } from "./contexts/NotificationContext";
 import { SocketProvider } from "./contexts/SocketContext";
 import { DownloadProvider } from "./contexts/DownloadContext";
+import { useTokenRefresh } from "./hooks/useTokenRefresh.js";
+
+/**
+ * Runs the token renewal loop. A component rather than a call inside
+ * `AuthProvider` because renewal goes through `apiFetch`, which needs both
+ * Auth and Notification in scope — and Auth is the outermost provider, so it
+ * cannot consume them itself.
+ *
+ * Renders nothing.
+ */
+function TokenRefresher() {
+  useTokenRefresh();
+  return null;
+}
 
 /**
  * The application's context stack, in dependency order.
@@ -15,6 +29,7 @@ export default function AppProviders({ children }) {
   return (
     <AuthProvider>
       <NotificationProvider>
+        <TokenRefresher />
         <SocketProvider>
           <DownloadProvider>{children}</DownloadProvider>
         </SocketProvider>

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -63,8 +63,12 @@ export default function Login({ height, toggleSignUpComponent }) {
       // Propagate it to the main app
       if (response.ok) {
         // AuthContext owns persistence; "remember me" decides whether the
-        // token outlives the tab.
-        setToken(data.token, { persist: rememberMe });
+        // token outlives the tab. `expiresAt` is the server's own `exp` claim
+        // — the renewal loop schedules off it rather than decoding the JWT.
+        setToken(data.token, {
+          persist: rememberMe,
+          expiresAt: data.expiresAt ?? null,
+        });
       } else {
         setSnack(`${data.message}`, "error");
       }

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -3,31 +3,60 @@ import PropTypes from "prop-types";
 
 export const AuthContext = createContext({
   token: null,
+  expiresAt: null,
   setToken: () => {},
   logout: () => {},
 });
 
+const TOKEN_KEY = "ytdiff_token";
+const EXPIRY_KEY = "ytdiff_token_expires_at";
+
 const getStoredToken = () => {
-  const stored = localStorage.getItem("ytdiff_token");
+  const stored = localStorage.getItem(TOKEN_KEY);
+  // The `"null"` guard is for tokens written by builds before the provider
+  // refactor, which stored the string instead of removing the key. Nothing
+  // writes it any more; this only has to outlive the browsers still holding
+  // one.
   return stored && stored !== "null" ? stored : null;
+};
+
+const getStoredExpiry = () => {
+  const stored = Number(localStorage.getItem(EXPIRY_KEY));
+  return Number.isFinite(stored) && stored > 0 ? stored : null;
 };
 
 export const AuthProvider = ({ children }) => {
   const [token, setTokenState] = useState(getStoredToken);
+  // Epoch *seconds*, as the server sends it — the `exp` claim of the live
+  // token. Kept beside the token so a reload can schedule the next renewal
+  // without waiting for a round trip.
+  const [expiresAt, setExpiresAt] = useState(getStoredExpiry);
 
   /**
    * Sets the live token. `persist: false` keeps it in memory only, which is
    * what an unticked "remember me" means: the session ends with the tab.
    *
+   * `expiresAt` travels with the token because they are one fact: a token
+   * stored without its expiry cannot be renewed on schedule, and an expiry
+   * left behind by a replaced token schedules the wrong renewal.
+   *
    * Memoised, because `apiFetch` and every effect that depends on it key off
    * the identity of these functions.
    */
-  const setToken = useCallback((newToken, { persist = true } = {}) => {
+  const setToken = useCallback((newToken, { persist = true, expiresAt: nextExpiry = null } = {}) => {
     setTokenState(newToken);
+    setExpiresAt(newToken ? nextExpiry : null);
+
     if (newToken && persist) {
-      localStorage.setItem("ytdiff_token", newToken);
+      localStorage.setItem(TOKEN_KEY, newToken);
+      if (nextExpiry) {
+        localStorage.setItem(EXPIRY_KEY, String(nextExpiry));
+      } else {
+        localStorage.removeItem(EXPIRY_KEY);
+      }
     } else {
-      localStorage.removeItem("ytdiff_token");
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(EXPIRY_KEY);
     }
   }, []);
 
@@ -36,8 +65,8 @@ export const AuthProvider = ({ children }) => {
   }, [setToken]);
 
   const value = useMemo(
-    () => ({ token, setToken, logout }),
-    [token, setToken, logout],
+    () => ({ token, expiresAt, setToken, logout }),
+    [token, expiresAt, setToken, logout],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/useTokenRefresh.js
+++ b/src/hooks/useTokenRefresh.js
@@ -1,0 +1,144 @@
+import { useCallback, useContext, useEffect, useRef } from "react";
+import { AuthContext } from "../contexts/AuthContext";
+import { useApi } from "./useApi.js";
+
+/**
+ * The largest delay `setTimeout` accepts — its argument is a signed 32-bit
+ * int, and anything past this fires immediately instead of never. The same
+ * clamp appears in `useSignedUrlRefresh` here and in the backend's socket
+ * expiry timer.
+ */
+const MAX_TIMEOUT = 2147483647;
+
+/** Renew once the token is this far through its life. */
+const RENEW_AFTER = 0.5;
+
+/** Never schedule a wake-up tighter than this, so a clock skew cannot spin. */
+const MIN_DELAY_MS = 30 * 1000;
+
+/**
+ * Keeps the session alive by re-stamping the token before it expires.
+ *
+ * Tokens used to last 31 days precisely so that nothing had to do this. They
+ * last a day now, which only works if the client renews — so this is the half
+ * of that change that keeps people logged in.
+ *
+ * Two triggers, because neither is sufficient alone:
+ *
+ * - A timer at the halfway mark, for a tab left open and visible.
+ * - `visibilitychange`, for a tab that was backgrounded or a laptop that was
+ *   asleep. Timers do not fire reliably across suspend, and browsers throttle
+ *   them hard in background tabs, so a tab woken after its timer should have
+ *   fired must not wait for a timer that already missed.
+ *
+ * Renewal runs through `apiFetch`, so a token that died while the machine was
+ * asleep gets the ordinary 401 path — one "Session expired" and a logout —
+ * rather than a special case here.
+ */
+export function useTokenRefresh() {
+  const { token, expiresAt, setToken } = useContext(AuthContext);
+  const apiFetch = useApi();
+  const timerRef = useRef(null);
+  const inFlightRef = useRef(false);
+
+  // Read by the scheduler without re-subscribing it on every token change.
+  const stateRef = useRef({ token, expiresAt });
+  stateRef.current = { token, expiresAt };
+
+  const refresh = useCallback(async () => {
+    // One renewal at a time: the timer and a visibility change can land
+    // together, and two in flight would have the loser store a token the
+    // winner already replaced.
+    if (inFlightRef.current) return null;
+    inFlightRef.current = true;
+    try {
+      // The body has to be a JSON object, not nothing: the server's
+      // `parseRequestJson` rejects an empty body with a 400 before the handler
+      // runs. `/isregallowed` takes the same empty `{}` for the same reason.
+      const response = await apiFetch("/refresh", {
+        method: "post",
+        body: JSON.stringify({}),
+      });
+      if (!response.ok) return null;
+
+      const data = await response.json();
+      if (!data?.token) return null;
+
+      // Renewal never upgrades a memory-only session to a persisted one: if
+      // the token is not in localStorage now, the replacement does not go
+      // there either.
+      const persist = localStorage.getItem("ytdiff_token") !== null;
+      setToken(data.token, { persist, expiresAt: data.expiresAt ?? null });
+      return data.expiresAt ?? null;
+    } catch {
+      // Offline, or the server is down. The existing token is still valid for
+      // now; the next trigger tries again.
+      return null;
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, [apiFetch, setToken]);
+
+  useEffect(() => {
+    const clear = () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    if (!token) {
+      clear();
+      return undefined;
+    }
+
+    /** Milliseconds until the token is `RENEW_AFTER` through its life. */
+    const msUntilRenewal = () => {
+      const { expiresAt: exp } = stateRef.current;
+      // No expiry to work from — the server did not send one, or this token
+      // predates the change. Fall back to a fixed hourly check rather than
+      // guessing at a lifetime.
+      if (!exp) return 60 * 60 * 1000;
+      const remainingMs = exp * 1000 - Date.now();
+      return remainingMs * RENEW_AFTER;
+    };
+
+    const schedule = () => {
+      clear();
+      const delay = Math.min(
+        Math.max(msUntilRenewal(), MIN_DELAY_MS),
+        MAX_TIMEOUT,
+      );
+      timerRef.current = setTimeout(async () => {
+        await refresh();
+        // Reschedule off whatever the new token says, rather than assuming
+        // the lifetime did not change under us.
+        if (stateRef.current.token) schedule();
+      }, delay);
+    };
+
+    const onWake = () => {
+      if (document.visibilityState !== "visible") return;
+      if (!stateRef.current.token) return;
+      // Past the halfway mark — the timer either already missed or is about
+      // to. Renew now and start a fresh schedule from the new expiry.
+      if (msUntilRenewal() <= 0) {
+        void refresh().then(() => {
+          if (stateRef.current.token) schedule();
+        });
+      } else {
+        schedule();
+      }
+    };
+
+    schedule();
+    document.addEventListener("visibilitychange", onWake);
+
+    return () => {
+      clear();
+      document.removeEventListener("visibilitychange", onWake);
+    };
+  }, [token, refresh]);
+
+  return refresh;
+}

--- a/tests/desktop/AuthContext.test.jsx
+++ b/tests/desktop/AuthContext.test.jsx
@@ -5,13 +5,21 @@ import { AuthContext, AuthProvider } from "../../src/contexts/AuthContext";
 
 /** Surfaces the context so the test can read the token and drive the setters. */
 function Probe() {
-  const { token, setToken, logout } = useContext(AuthContext);
+  const { token, expiresAt, setToken, logout } = useContext(AuthContext);
   return (
     <div>
       <span data-testid="token">{token === null ? "none" : token}</span>
+      <span data-testid="expiresAt">
+        {expiresAt === null ? "none" : String(expiresAt)}
+      </span>
       <button onClick={() => setToken("t_persisted")}>persist</button>
       <button onClick={() => setToken("t_session", { persist: false })}>
         session only
+      </button>
+      <button
+        onClick={() => setToken("t_dated", { expiresAt: 1893456000 })}
+      >
+        with expiry
       </button>
       <button onClick={logout}>logout</button>
     </div>
@@ -66,5 +74,52 @@ describe("AuthContext (Desktop)", () => {
 
     expect(screen.getByTestId("token")).toHaveTextContent("none");
     expect(localStorage.getItem("ytdiff_token")).toBeNull();
+  });
+
+  test("stores the expiry alongside the token", () => {
+    renderProvider();
+    fireEvent.click(screen.getByText("with expiry"));
+
+    expect(screen.getByTestId("expiresAt")).toHaveTextContent("1893456000");
+    expect(localStorage.getItem("ytdiff_token_expires_at")).toBe("1893456000");
+  });
+
+  test("reads a stored expiry back on mount", () => {
+    localStorage.setItem("ytdiff_token", "stored_token");
+    localStorage.setItem("ytdiff_token_expires_at", "1893456000");
+    renderProvider();
+
+    expect(screen.getByTestId("expiresAt")).toHaveTextContent("1893456000");
+  });
+
+  test("ignores a corrupt stored expiry rather than scheduling off it", () => {
+    // A NaN here would make the renewal maths produce NaN and the timer fire
+    // immediately, in a loop.
+    localStorage.setItem("ytdiff_token", "stored_token");
+    localStorage.setItem("ytdiff_token_expires_at", "not-a-number");
+    renderProvider();
+
+    expect(screen.getByTestId("expiresAt")).toHaveTextContent("none");
+  });
+
+  test("a token stored with no expiry leaves no stale one behind", () => {
+    localStorage.setItem("ytdiff_token_expires_at", "1893456000");
+    renderProvider();
+    fireEvent.click(screen.getByText("persist"));
+
+    // The new token has no expiry; the previous token's must not be reused
+    // for it.
+    expect(localStorage.getItem("ytdiff_token_expires_at")).toBeNull();
+    expect(screen.getByTestId("expiresAt")).toHaveTextContent("none");
+  });
+
+  test("logout clears the expiry too", () => {
+    renderProvider();
+    fireEvent.click(screen.getByText("with expiry"));
+    fireEvent.click(screen.getByText("logout"));
+
+    expect(screen.getByTestId("token")).toHaveTextContent("none");
+    expect(screen.getByTestId("expiresAt")).toHaveTextContent("none");
+    expect(localStorage.getItem("ytdiff_token_expires_at")).toBeNull();
   });
 });

--- a/tests/desktop/Login.test.jsx
+++ b/tests/desktop/Login.test.jsx
@@ -107,8 +107,12 @@ describe("Login Component (Desktop)", () => {
     );
 
     await waitFor(() => {
+      // expiresAt is null when the server did not send one — an older backend,
+      // or a token with no exp claim. The renewal loop falls back to a fixed
+      // interval rather than guessing a lifetime.
       expect(contexts.auth.setToken).toHaveBeenCalledWith("mock_token", {
         persist: false,
+        expiresAt: null,
       });
     });
   });
@@ -121,7 +125,10 @@ describe("Login Component (Desktop)", () => {
 
     globalThis.fetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ token: "mock_token_remembered" }),
+      json: async () => ({
+        token: "mock_token_remembered",
+        expiresAt: 1893456000,
+      }),
     });
 
     renderLogin();
@@ -139,9 +146,11 @@ describe("Login Component (Desktop)", () => {
     fireEvent.click(loginButton);
 
     await waitFor(() => {
+      // The server's own exp claim is handed straight to AuthContext; the
+      // client never decodes the JWT to find it.
       expect(contexts.auth.setToken).toHaveBeenCalledWith(
         "mock_token_remembered",
-        { persist: true },
+        { persist: true, expiresAt: 1893456000 },
       );
     });
   });

--- a/tests/desktop/useTokenRefresh.test.jsx
+++ b/tests/desktop/useTokenRefresh.test.jsx
@@ -1,0 +1,223 @@
+import React from "react";
+import { render, act, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { AuthContext } from "../../src/contexts/AuthContext";
+import { NotificationContext } from "../../src/contexts/NotificationContext";
+import { useTokenRefresh } from "../../src/hooks/useTokenRefresh";
+
+function Harness() {
+  useTokenRefresh();
+  return null;
+}
+
+/** Epoch seconds, `secs` from now — the shape the server sends. */
+const expiryIn = (secs) => Math.floor(Date.now() / 1000) + secs;
+
+let auth;
+let setVisibility;
+
+function renderRefresher({ token = "live_token", expiresAt = expiryIn(3600) } = {}) {
+  auth = {
+    token,
+    expiresAt,
+    setToken: vi.fn(),
+    logout: vi.fn(),
+  };
+  return render(
+    <AuthContext.Provider value={auth}>
+      <NotificationContext.Provider value={{ notify: vi.fn() }}>
+        <Harness />
+      </NotificationContext.Provider>
+    </AuthContext.Provider>,
+  );
+}
+
+function mockRefreshResponse(body, ok = true) {
+  globalThis.fetch.mockResolvedValueOnce({ ok, status: ok ? 200 : 401, json: async () => body });
+}
+
+describe("useTokenRefresh (Desktop)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.clear();
+    globalThis.fetch = vi.fn();
+    setVisibility = (state) => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => state,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("does not schedule anything without a token", () => {
+    renderRefresher({ token: null, expiresAt: null });
+    act(() => {
+      vi.advanceTimersByTime(48 * 60 * 60 * 1000);
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("renews at the halfway mark, not at expiry", async () => {
+    // An hour-long token renews around the 30-minute mark. Renewing at expiry
+    // would leave no room for a failed attempt.
+    renderRefresher({ expiresAt: expiryIn(3600) });
+    mockRefreshResponse({ token: "renewed", expiresAt: expiryIn(7200) });
+
+    act(() => {
+      vi.advanceTimersByTime(29 * 60 * 1000);
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 60 * 1000);
+    });
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+    expect(globalThis.fetch.mock.calls[0][0]).toBe(
+      "http://localhost:8888/ytdiff/refresh",
+    );
+    // A body, not nothing: the server rejects an empty body with a 400 before
+    // the refresh handler ever runs.
+    expect(globalThis.fetch.mock.calls[0][1]).toMatchObject({
+      method: "post",
+      body: "{}",
+    });
+  });
+
+  test("stores the renewed token with its new expiry", async () => {
+    localStorage.setItem("ytdiff_token", "live_token");
+    renderRefresher({ expiresAt: expiryIn(3600) });
+    const nextExpiry = expiryIn(7200);
+    mockRefreshResponse({ token: "renewed", expiresAt: nextExpiry });
+
+    await act(async () => {
+      vi.advanceTimersByTime(31 * 60 * 1000);
+    });
+
+    await waitFor(() =>
+      expect(auth.setToken).toHaveBeenCalledWith("renewed", {
+        persist: true,
+        expiresAt: nextExpiry,
+      }),
+    );
+  });
+
+  test("a memory-only session is not promoted to a persisted one", async () => {
+    // "Remember me" was unticked, so the token is not in localStorage. The
+    // renewal must not put it there.
+    renderRefresher({ expiresAt: expiryIn(3600) });
+    mockRefreshResponse({ token: "renewed", expiresAt: expiryIn(7200) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(31 * 60 * 1000);
+    });
+
+    await waitFor(() =>
+      expect(auth.setToken).toHaveBeenCalledWith(
+        "renewed",
+        expect.objectContaining({ persist: false }),
+      ),
+    );
+  });
+
+  test("renews on wake when the timer was missed", async () => {
+    // A backgrounded tab or a sleeping laptop: the token is already past its
+    // halfway mark when the tab comes back, and the timer that should have
+    // fired did not. Waiting for it would let the session die.
+    renderRefresher({ expiresAt: expiryIn(60) });
+    mockRefreshResponse({ token: "renewed", expiresAt: expiryIn(3600) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(45 * 1000);
+      setVisibility("visible");
+    });
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+  });
+
+  test("a visibilitychange to hidden does not renew", async () => {
+    // Only a wake counts. A tab being backgrounded fires the same event, and
+    // acting on it would renew on every tab switch.
+    renderRefresher({ expiresAt: expiryIn(3600) });
+    await act(async () => {
+      setVisibility("hidden");
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("waking early reschedules instead of renewing", async () => {
+    renderRefresher({ expiresAt: expiryIn(3600) });
+    await act(async () => {
+      setVisibility("visible");
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("a failed renewal leaves the existing token alone", async () => {
+    // Offline, or the server is down. The token in hand is still valid; the
+    // next trigger tries again. Clearing it here would log the user out for a
+    // transient network blip.
+    renderRefresher({ expiresAt: expiryIn(3600) });
+    globalThis.fetch.mockRejectedValueOnce(new Error("offline"));
+
+    await act(async () => {
+      vi.advanceTimersByTime(31 * 60 * 1000);
+    });
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(auth.setToken).not.toHaveBeenCalled();
+  });
+
+  test("a 401 does not store a token", async () => {
+    // apiFetch owns the logout on 401; this hook must not also act on it.
+    renderRefresher({ expiresAt: expiryIn(3600) });
+    mockRefreshResponse({ status: "error" }, false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(31 * 60 * 1000);
+    });
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(auth.setToken).not.toHaveBeenCalled();
+  });
+
+  test("falls back to an hourly check when the server sent no expiry", async () => {
+    renderRefresher({ expiresAt: null });
+    mockRefreshResponse({ token: "renewed", expiresAt: expiryIn(3600) });
+
+    act(() => {
+      vi.advanceTimersByTime(59 * 60 * 1000);
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 60 * 1000);
+    });
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+  });
+
+  test("stops renewing after logout", async () => {
+    const { rerender } = renderRefresher({ expiresAt: expiryIn(3600) });
+
+    rerender(
+      <AuthContext.Provider
+        value={{ ...auth, token: null, expiresAt: null }}
+      >
+        <NotificationContext.Provider value={{ notify: vi.fn() }}>
+          <Harness />
+        </NotificationContext.Provider>
+      </AuthContext.Provider>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(48 * 60 * 60 * 1000);
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Client half of audit finding **F7**. The backend PR ([sagniKdas53/yt-diff#110](https://github.com/sagniKdas53/yt-diff/pull/110)) cuts the default token lifetime from 31 days to 24 hours; that only works if the client renews, so this is the half that keeps people logged in.

**Merge this one first.** The backend PR re-points the `frontend` submodule only after this lands, following the same order as #82.

## What changed

`useTokenRefresh` renews on two triggers, because neither is sufficient alone:

- **A timer at the halfway mark** of the token's life, for a tab left open and visible.
- **`visibilitychange`**, for a backgrounded tab or a laptop that was asleep. Timers do not survive suspend and browsers throttle them hard in background tabs, so a tab woken *after* its timer should have fired must not sit waiting for a timer that already missed.

A wake arriving *before* the halfway mark reschedules rather than renewing, so tab switching does not turn into one request per switch.

`AuthContext` now carries `expiresAt` beside the token. They are one fact: a token stored without its expiry cannot be renewed on schedule, and an expiry left behind by a replaced token schedules the wrong renewal. The value is the server's own `exp` claim, handed over in the login and refresh responses — the client never decodes a JWT it has no key to verify.

`TokenRefresher` is a component in `AppProviders` rather than a call inside `AuthProvider`, because renewal goes through `apiFetch`, which needs both Auth and Notification in scope — and Auth is the outermost provider, so it cannot consume them itself.

## Failure modes handled

| Case | Behaviour |
| :--- | :--- |
| Token died while the machine slept | The ordinary `apiFetch` 401 path — one "Session expired" and a logout. No special case in the hook. |
| Renewal fails (offline, server down) | The existing token is left alone. It is still valid, and clearing it would log someone out over a transient blip. |
| Timer and a wake land together | Collapsed to one in-flight renewal; otherwise the loser stores a token the winner already replaced. |
| Server sends no `expiresAt` | Falls back to a fixed hourly check rather than guessing a lifetime. |
| Corrupt stored expiry | Ignored. `NaN` would make the renewal maths fire the timer immediately, in a loop. |
| "Remember me" was unticked | Renewal never promotes a memory-only session to a persisted one. |

## Notes for review

- The refresh POST sends `body: "{}"` deliberately — the server's `parseRequestJson` rejects an empty body with a 400 before any handler runs. `/isregallowed` takes the same empty `{}` for the same reason.
- `MAX_TIMEOUT` clamps to 2147483647, matching `useSignedUrlRefresh` here and the backend's socket expiry timer.
- The two changed assertions in `Login.test.jsx` pinned the old `setToken` call shape; they now also assert the expiry is forwarded.

## Verification

- `npm run lint` — clean (`--max-warnings 0`).
- `npx vitest run` — **89 passed**, up from 73. Both viewport projects.
- `npm run build` — succeeds; output has no inline scripts, so the backend's new `script-src 'self'` is satisfied by the real bundle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzcPummsvwEU486Ta5ezkS)_