### PR TITLE
Centralize API response handling with ApiClient

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,103 @@
+/**
+ * A response the server refused, or one that could not be read as the JSON
+ * the API is documented to return.
+ *
+ * `message` is the server's own, when it sent one: the backend answers errors
+ * as `{status: "error", message}` and, on a few paths, `{error}`. Callers used
+ * to dig that out themselves, each in its own way, and each with its own
+ * fallback for when it was not there.
+ */
+export class ApiError extends Error {
+  constructor(status, message, body) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+    /**
+     * True when this was a dead session rather than a rejected request.
+     * `apiFetch` has already told the user and logged them out, so a caller
+     * that reports this again would say it twice. A 401 from `/login` is a
+     * wrong password, not an expired session, and is not marked.
+     */
+    this.sessionExpired = false;
+  }
+}
+
+/**
+ * Reads the server's error message out of a refused response.
+ *
+ * The body is best-effort: a refusal that never reached this app's own error
+ * path — a proxy's HTML 502, say — has no JSON in it, and the status line is
+ * then the only thing left to report.
+ */
+async function errorFrom(response) {
+  const body = await response.json().catch(() => null);
+  const message =
+    body?.message ||
+    body?.error ||
+    response.statusText ||
+    `Request failed (${response.status})`;
+
+  return new ApiError(response.status, message, body);
+}
+
+/**
+ * The one place an API response is turned into a value.
+ *
+ * `apiFetch` owns the request side — base URL, JSON headers, the bearer token,
+ * and logging out on a dead session. What it does not own is the other half of
+ * every call: encoding the body, checking `response.ok`, and parsing. Those
+ * were restated at nineteen call sites, in three different spellings of the
+ * parse alone — `response.json()`, `JSON.parse(await response.text())`, and
+ * `.json().catch(() => response.statusText)` — each with its own idea of what
+ * a failure looks like.
+ *
+ * A refused request throws `ApiError` rather than returning a response for the
+ * caller to inspect, so the failure path cannot be forgotten — the previous
+ * shape let a missing `if (!response.ok)` read an error body as data.
+ *
+ * @param apiFetch - The transport from `useApi`.
+ * @param hadToken - Whether the transport is carrying a session. Decides
+ *   whether a 401 means "expired" (already reported) or "rejected".
+ */
+export function createApiClient(apiFetch, hadToken = false) {
+  /**
+   * POSTs `body` as JSON to `path` and returns the parsed response.
+   *
+   * @param {string} path - Backend-relative, e.g. "/getsub".
+   * @param {object} [body] - Serialized as the request body. Omit for none.
+   * @param {object} [options]
+   * @param {AbortSignal} [options.signal] - Cancels the request.
+   * @param {object} [options.headers] - Overrides, e.g. a different Accept.
+   * @returns {Promise<any>} The parsed response body.
+   * @throws {ApiError} On any non-2xx, or on a body that is not JSON.
+   */
+  async function post(path, body, { signal, headers } = {}) {
+    const response = await apiFetch(path, {
+      method: "post",
+      ...(signal ? { signal } : {}),
+      ...(headers ? { headers } : {}),
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+
+    if (!response.ok) {
+      const error = await errorFrom(response);
+      error.sessionExpired = response.status === 401 && hadToken;
+      throw error;
+    }
+
+    // Every endpoint answers with JSON, so a body that will not parse is a
+    // real fault worth surfacing rather than something to shrug off as empty.
+    try {
+      return await response.json();
+    } catch {
+      throw new ApiError(
+        response.status,
+        "The server sent a response this app could not read",
+        null,
+      );
+    }
+  }
+
+  return { post };
+}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -23,6 +23,7 @@ import {
   useState,
 } from "react";
 import { useDependencyLogger } from "../hooks/useDependencyLogger.js";
+import { useLatest } from "../hooks/useLatest.js";
 import { AuthContext } from "../contexts/AuthContext";
 import { SocketContext } from "../contexts/SocketContext";
 import { NotificationContext } from "../contexts/NotificationContext";
@@ -248,21 +249,17 @@ export default function App() {
   );
 
   // --- Refs to avoid stale closures ---
+  // The socket effect below registers its handlers once and must not
+  // re-subscribe, so anything they read has to reach them through a box rather
+  // than through the closure they were registered in. `useLatest` is that box;
+  // see its own note for why it writes during render.
+  //
   // Only for values that actually change between renders; the callbacks the
   // providers hand out are already stable.
-  // Synced in render phase instead of useEffect to avoid delay
-  const playListUrlRef = useRef(playListUrl);
-  playListUrlRef.current = playListUrl;
-
-  const disableProgressRef = useRef(disableProgress);
-  disableProgressRef.current = disableProgress;
-
-  const toggleProgressCallBackRef = useRef(toggleProgressCallBack);
-  toggleProgressCallBackRef.current = toggleProgressCallBack;
-
-  // Mobile ref — so socket handlers can check mobile state without stale closures
-  const isMobileRef = useRef(isMobile);
-  isMobileRef.current = isMobile;
+  const playListUrlRef = useLatest(playListUrl);
+  const disableProgressRef = useLatest(disableProgress);
+  const toggleProgressCallBackRef = useLatest(toggleProgressCallBack);
+  const isMobileRef = useLatest(isMobile);
 
   const connectionGenerationRef = useRef(null);
 

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -13,12 +13,13 @@ import PropTypes from "prop-types";
 import { useContext, useEffect, useState } from "react";
 import { AuthContext } from "../contexts/AuthContext";
 import { NotificationContext } from "../contexts/NotificationContext";
-import { useApi } from "../hooks/useApi.js";
+import { ApiError } from "../api/client.js";
+import { useApiClient } from "../hooks/useApiClient.js";
 
 export default function Login({ height, toggleSignUpComponent }) {
   const { setToken } = useContext(AuthContext);
   const { setSnack } = useContext(NotificationContext);
-  const apiFetch = useApi();
+  const api = useApiClient();
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -50,30 +51,25 @@ export default function Login({ height, toggleSignUpComponent }) {
     }
     setLoading(true);
     try {
-      const response = await apiFetch("/login", {
-        method: "post",
-        body: JSON.stringify({
-          username,
-          password,
-        }),
-      });
+      const data = await api.post("/login", { username, password });
 
-      // Handle response (e.g., store token)
-      const data = await response.json();
-      // Propagate it to the main app
-      if (response.ok) {
-        // AuthContext owns persistence; "remember me" decides whether the
-        // token outlives the tab. `expiresAt` is the server's own `exp` claim
-        // — the renewal loop schedules off it rather than decoding the JWT.
-        setToken(data.token, {
-          persist: rememberMe,
-          expiresAt: data.expiresAt ?? null,
-        });
-      } else {
-        setSnack(`${data.message}`, "error");
-      }
-    } catch (_error) {
-      setSnack("Login failed. Please check your credentials.", "error");
+      // AuthContext owns persistence; "remember me" decides whether the
+      // token outlives the tab. `expiresAt` is the server's own `exp` claim
+      // — the renewal loop schedules off it rather than decoding the JWT.
+      setToken(data.token, {
+        persist: rememberMe,
+        expiresAt: data.expiresAt ?? null,
+      });
+    } catch (error) {
+      // A refusal carries the server's own message -- and a 401 here is a
+      // wrong password, not a dead session, so it is reported like any other.
+      // Anything that is not an ApiError never reached the server.
+      setSnack(
+        error instanceof ApiError
+          ? error.message
+          : "Login failed. Please check your credentials.",
+        "error",
+      );
     } finally {
       setLoading(false);
     }
@@ -81,21 +77,15 @@ export default function Login({ height, toggleSignUpComponent }) {
 
   const regEnableCheck = async () => {
     try {
-      const response = await apiFetch("/isregallowed", {
-        method: "post",
-        body: JSON.stringify({
-          sendStats: false,
-        }),
-      });
-
-      const data = await response.json();
-      if (response.ok) {
-        setIsSignUpEnabled(data.registrationAllowed);
-      } else {
-        setSnack(`${data.message}`, "error");
-      }
-    } catch (_error) {
-      setSnack("Error in checking signup availability", "error");
+      const data = await api.post("/isregallowed", { sendStats: false });
+      setIsSignUpEnabled(data.registrationAllowed);
+    } catch (error) {
+      setSnack(
+        error instanceof ApiError
+          ? error.message
+          : "Error in checking signup availability",
+        "error",
+      );
     }
   };
 

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -40,13 +40,14 @@ import { useContext, useState } from "react";
 import { AuthContext } from "../contexts/AuthContext";
 import { SocketContext } from "../contexts/SocketContext";
 import { NotificationContext } from "../contexts/NotificationContext";
-import { useApi } from "../hooks/useApi.js";
+import { ApiError } from "../api/client.js";
+import { useApiClient } from "../hooks/useApiClient.js";
 
 export default function Navigation({ themeSwitcher, theme, setPlayListUrl }) {
   const { token, setToken, logout } = useContext(AuthContext);
   const { connectionId, setConnectionId } = useContext(SocketContext);
   const { setSnack, addNotification } = useContext(NotificationContext);
-  const apiFetch = useApi();
+  const api = useApiClient();
 
   const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
 
@@ -95,22 +96,20 @@ export default function Navigation({ themeSwitcher, theme, setPlayListUrl }) {
 
       setReindexOpen(false);
 
-      const response = await apiFetch("/reindexall", {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
+      const data = await api.post("/reindexall", body);
 
-      const data = await response.json();
-      if (response.ok) {
-        setSnack(data.message || "Batch re-index started", "success");
-        addNotification(data.message || "Batch re-index started", "success");
-      } else {
-        setSnack(data.message || "Failed to start re-index", "error");
-        addNotification(data.message || "Failed to start re-index", "error");
-      }
+      const message = data.message || "Batch re-index started";
+      setSnack(message, "success");
+      addNotification(message, "success");
     } catch (error) {
-      setSnack("Network error: " + error.message, "error");
-      addNotification("Network error: " + error.message, "error");
+      // An ApiError is a refusal and carries the server's own message; a
+      // transport failure never reached the server and gets said as one.
+      const message =
+        error instanceof ApiError
+          ? error.message || "Failed to start re-index"
+          : "Network error: " + error.message;
+      setSnack(message, "error");
+      addNotification(message, "error");
     }
   };
 
@@ -302,9 +301,8 @@ Navigation.propTypes = {
 };
 
 function NotificationDrawer({ connectionId, badgeColor }) {
-  const { notifications, dismissNotification } = useContext(
-    NotificationContext,
-  );
+  const { notifications, dismissNotification } =
+    useContext(NotificationContext);
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("all");
 

--- a/src/components/PlayList.jsx
+++ b/src/components/PlayList.jsx
@@ -32,10 +32,18 @@ import TableSortLabel from "@mui/material/TableSortLabel";
 import TextField from "@mui/material/TextField";
 import debounce from "lodash.debounce";
 import PropTypes from "prop-types";
-import { memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useDependencyLogger } from "../hooks/useDependencyLogger.js";
 import { NotificationContext } from "../contexts/NotificationContext";
-import { useApi } from "../hooks/useApi.js";
+import { ApiError } from "../api/client.js";
+import { useApiClient } from "../hooks/useApiClient.js";
 import TablePaginationActions from "./Pagination.jsx";
 import PlayListItemRow from "./PlayListItemRow.jsx";
 
@@ -67,7 +75,7 @@ function PlayList({
   mobileAddDialogRef,
 }) {
   const { setSnack, addNotification } = useContext(NotificationContext);
-  const apiFetch = useApi();
+  const api = useApiClient();
 
   const [query, updateQuery] = useState("");
   // "1" == ID [Default], "3" == lastUpdatedByScheduler
@@ -184,41 +192,32 @@ function PlayList({
   };
 
   const postUrlList = async (urlList) => {
-    //console.log("Posting urlList: " + urlList);
-    const response = await apiFetch("/list", {
-      method: "post",
-      body: JSON.stringify({
+    try {
+      const json_data = await api.post("/list", {
         urlList: urlList,
         // This is to make sure that we can get the requested amount + 1 so that we can paginate properly
         chunkSize: rowsPerPageSubList + 1,
         monitoringType: watch,
         sleep: true,
-      }),
-    });
-    if (response.ok) {
-      const data = await response.text();
-      const json_data = JSON.parse(data);
-      //console.log("postUrl response: ", json_data);
+      });
+
       // queueDepthBefore counts what was already pending when this submission
       // landed — the user's own items are not included. Worth mentioning only
       // when there is a real backlog (a batch re-index, typically); submitting
       // a handful into an empty queue needs no explanation.
       const queuedAhead = json_data.queueDepthBefore ?? 0;
       if (queuedAhead > QUEUE_DEPTH_NOTICE_THRESHOLD) {
-        setSnack(
-          `Added to listing queue — ${queuedAhead} ahead`,
-          "info",
-        );
+        setSnack(`Added to listing queue — ${queuedAhead} ahead`, "info");
       }
       return json_data;
-    } else {
-      // 401 is already reported and logged out by apiFetch.
-      if (response.status === 429) {
+    } catch (error) {
+      if (error.status === 429) {
         setSnack(
           "Too many requests. Please wait before queuing more.",
           "error",
         );
       }
+      // A dead session has already been reported once, by apiFetch.
       return {};
     }
   };
@@ -240,19 +239,14 @@ function PlayList({
     cleanUp,
   ) => {
     setSnack("Deleting playlist…", "info");
-    const response = await apiFetch("/delplay", {
-      method: "post",
-      body: JSON.stringify({
+    try {
+      const json_data = await api.post("/delplay", {
         playListUrl: playListUrlToDelete,
         deleteAllVideosInPlaylist: deleteAllVideosInPlaylist,
         deletePlaylist: deletePlaylist,
         cleanUp: cleanUp,
-      }),
-    });
-    if (response.ok) {
-      const data = await response.text();
-      const json_data = JSON.parse(data);
-      //console.log("deletePlaylist response: ", json_data);
+      });
+
       setSnack("Playlist deleted successfully.", "success");
       addNotification(
         `Deleted ${title ? title : playListUrlToDelete}. Details: ${json_data.message}`,
@@ -273,8 +267,7 @@ function PlayList({
       if (playListUrlToDelete === playListUrl) {
         setPlayListUrl("init");
       }
-    }
-    if (!response.ok) {
+    } catch (_error) {
       setSnack("Failed to delete playlist.", "error");
       addNotification(
         `Failed to delete playlist: ${title ? title : playListUrlToDelete}`,
@@ -288,47 +281,31 @@ function PlayList({
 
     const fetchPlaylists = async () => {
       try {
-        const response = await apiFetch("/getplay", {
-          method: "post",
-          body: JSON.stringify({
-            start: start,
-            stop: stop,
-            sort: sort,
-            order: order,
-            query: query,
-          }),
+        const json_data = await api.post("/getplay", {
+          start: start,
+          stop: stop,
+          sort: sort,
+          order: order,
+          query: query,
         });
 
-        if (response.ok) {
-          const data = await response.text();
-          if (active) {
-            const json_data = JSON.parse(data);
-            setItems(json_data["rows"]);
-            setTotalItems(json_data["count"]);
-          }
-        } else {
-          // 401 is already reported and logged out by apiFetch.
-          if (active) {
-            setItems([
-              {
-                playlistUrl: "",
-                title: `Error in fetching playlists: ${response.status} ${response.statusText}`,
-                sortOrder: 0,
-                monitoringType: "N/A",
-                saveDirectory: "",
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-              },
-            ]);
-            setTotalItems(1);
-          }
+        if (active) {
+          setItems(json_data["rows"]);
+          setTotalItems(json_data["count"]);
         }
       } catch (error) {
         if (active) {
+          // The list itself is the only place there is to say this, so the
+          // failure is rendered as the one row the table can show. A refusal
+          // carries the server's message; anything else never reached it.
+          const title =
+            error instanceof ApiError
+              ? `Error in fetching playlists: ${error.status} ${error.message}`
+              : `Network error: ${error.message}`;
           setItems([
             {
               playlistUrl: "",
-              title: `Network error: ${error.message}`,
+              title,
               sortOrder: 0,
               monitoringType: "N/A",
               saveDirectory: "",
@@ -346,7 +323,7 @@ function PlayList({
     return () => {
       active = false;
     };
-  }, [apiFetch, start, stop, sort, order, query, reFetch]);
+  }, [api, start, stop, sort, order, query, reFetch]);
 
   const handleChangePage = useCallback(
     (_event, newPage) => {
@@ -408,31 +385,30 @@ function PlayList({
   }, [playListIndex, handleChangePage, rowsPerPage, totalItems]);
 
   const changeWatch = async (event, url) => {
-    // add some error handling here for gods sake
-    const response = await apiFetch("/watch", {
-      method: "post",
-      body: JSON.stringify({
+    try {
+      const json_data = await api.post("/watch", {
         url: url,
         watch: event.target.value,
-      }),
-    });
-    if (response.ok) {
-      const data = await response.text();
-      const json_data = JSON.parse(data);
-      if (json_data["status"] === "success") {
-        const updatedItems = [...items];
-        const itemIndex = updatedItems.findIndex(
-          (item) => item.playlistUrl === url,
-        );
-        const updatedItem = {
-          ...updatedItems[itemIndex],
-          monitoringType: event.target.value,
-        };
-        updatedItems[itemIndex] = updatedItem;
-        setItems(updatedItems);
+      });
+      if (json_data["status"] !== "success") return;
+
+      const updatedItems = [...items];
+      const itemIndex = updatedItems.findIndex(
+        (item) => item.playlistUrl === url,
+      );
+      const updatedItem = {
+        ...updatedItems[itemIndex],
+        monitoringType: event.target.value,
+      };
+      updatedItems[itemIndex] = updatedItem;
+      setItems(updatedItems);
+    } catch (error) {
+      // The select keeps showing the old value, which is the truth. A dead
+      // session has already been reported once, by apiFetch.
+      if (!error.sessionExpired) {
+        setSnack(`Failed to change monitoring type: ${error.message}`, "error");
       }
     }
-    // 401 is already reported and logged out by apiFetch.
   };
 
   const lastUpdateCalc = (lastStamp) => {

--- a/src/components/PlayerPlaylistDrawer.jsx
+++ b/src/components/PlayerPlaylistDrawer.jsx
@@ -112,6 +112,11 @@ export default function PlayerPlaylistDrawer({
               <Avatar
                 variant="rounded"
                 src={thumbImg}
+                // The drawer lists a whole playlist, so most of these are
+                // scrolled well past the viewport. Avatar renders its own
+                // <img>, which is the only element the attribute means
+                // anything on.
+                slotProps={{ img: { loading: "lazy" } }}
                 sx={{ width: 60, height: 45, mr: 1 }}
               />
             </ListItemAvatar>

--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -11,11 +11,12 @@ import Grid from "@mui/material/Unstable_Grid2";
 import PropTypes from "prop-types";
 import { useContext, useState } from "react";
 import { NotificationContext } from "../contexts/NotificationContext";
-import { useApi } from "../hooks/useApi.js";
+import { ApiError } from "../api/client.js";
+import { useApiClient } from "../hooks/useApiClient.js";
 
 export default function Signup({ height, toggleSignUpComponent }) {
   const { setSnack } = useContext(NotificationContext);
-  const apiFetch = useApi();
+  const api = useApiClient();
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -40,25 +41,17 @@ export default function Signup({ height, toggleSignUpComponent }) {
     }
     setLoading(true);
     try {
-      const response = await apiFetch("/register", {
-        method: "post",
-        body: JSON.stringify({
-          username,
-          password,
-        }),
-      });
+      await api.post("/register", { username, password });
 
-      // Handle response (e.g., store token)
-      const data = await response.json();
-      // Propagate it to the main app
-      if (response.ok) {
-        setSnack("Account successfully created.", "success");
-        toggleSignUpComponent(false);
-      } else {
-        setSnack(`${data.message}`, "error");
-      }
-    } catch (_error) {
-      setSnack("Signup failed.", "error");
+      setSnack("Account successfully created.", "success");
+      toggleSignUpComponent(false);
+    } catch (error) {
+      // A refusal carries the server's own message; anything else never
+      // reached the server.
+      setSnack(
+        error instanceof ApiError ? error.message : "Signup failed.",
+        "error",
+      );
     } finally {
       setLoading(false);
     }
@@ -72,7 +65,10 @@ export default function Signup({ height, toggleSignUpComponent }) {
       spacing={0}
       sx={{ my: 0, p: 0, height: height }}
     >
-      <form onSubmit={handleSignup} style={{ width: "100%", maxWidth: "360px" }}>
+      <form
+        onSubmit={handleSignup}
+        style={{ width: "100%", maxWidth: "360px" }}
+      >
         <Grid container spacing={3} sx={{ m: 1 }}>
           <Grid xs={12} sx={{ alignItems: "center" }}>
             <Typography component="h1" variant="h5">

--- a/src/components/SubList.jsx
+++ b/src/components/SubList.jsx
@@ -37,7 +37,8 @@ import {
 import { useDependencyLogger } from "../hooks/useDependencyLogger.js";
 import { NotificationContext } from "../contexts/NotificationContext";
 import { DownloadContext } from "../contexts/DownloadContext";
-import { useApi } from "../hooks/useApi.js";
+import { ApiError } from "../api/client.js";
+import { useApiClient } from "../hooks/useApiClient.js";
 import { assetBase } from "../config.js";
 import TablePaginationActions from "./Pagination.jsx";
 import SubListItemCard from "./SubListItemCard.jsx";
@@ -63,7 +64,7 @@ function SubList({
   const { setSnack, addNotification } = useContext(NotificationContext);
   const { activeDownloads, queuedItems, queueDownloads } =
     useContext(DownloadContext);
-  const apiFetch = useApi();
+  const api = useApiClient();
 
   // Query and sort state
   const [query, updateQuery] = useState("");
@@ -130,42 +131,35 @@ function SubList({
       }
 
       try {
-        const response = await apiFetch("/refreshfiles", {
-          method: "post",
-          body: JSON.stringify({
-            fileIds: dueEntries.map(([, entry]) => entry.fileId),
-          }),
+        const data = await api.post("/refreshfiles", {
+          fileIds: dueEntries.map(([, entry]) => entry.fileId),
         });
 
-        if (response.ok) {
-          const data = await response.json();
-          if (data.status === "success" && data.files) {
-            dueEntries.forEach(([fileName, entry]) => {
-              const refreshed = Reflect.get(data.files, entry.fileId);
-              if (refreshed?.expiry) {
-                Reflect.set(thumbMetaRef.current, fileName, {
-                  ...Reflect.get(thumbMetaRef.current, fileName),
-                  expiry: refreshed.expiry,
-                });
-              } else {
-                Reflect.deleteProperty(thumbMetaRef.current, fileName);
-                setThumbUrls((prev) => {
-                  const next = { ...prev };
-                  Reflect.set(next, fileName, null);
-                  return next;
-                });
-              }
-            });
-          }
+        if (data.status === "success" && data.files) {
+          dueEntries.forEach(([fileName, entry]) => {
+            const refreshed = Reflect.get(data.files, entry.fileId);
+            if (refreshed?.expiry) {
+              Reflect.set(thumbMetaRef.current, fileName, {
+                ...Reflect.get(thumbMetaRef.current, fileName),
+                expiry: refreshed.expiry,
+              });
+            } else {
+              Reflect.deleteProperty(thumbMetaRef.current, fileName);
+              setThumbUrls((prev) => {
+                const next = { ...prev };
+                Reflect.set(next, fileName, null);
+                return next;
+              });
+            }
+          });
         }
-        // 401 is already reported and logged out by apiFetch.
       } catch (_error) {
         // Let the next bulk fetch recover if this refresh fails.
       }
 
       scheduleThumbnailRefresh();
     }, refreshTime);
-  }, [apiFetch, clearThumbnailRefreshTimer]);
+  }, [api, clearThumbnailRefreshTimer]);
   // const functions and normal functions
   const handleChangePage = useCallback(
     (_event, newPage) => {
@@ -274,28 +268,11 @@ function SubList({
         // perform the request and stream the response so we can report progress
         //console.log("Requesting file: ", { saveDirectory, fileName });
         setSnack(`Downloading: ${fileName}`, "info");
-        const response = await apiFetch("/getfile", {
-          method: "post",
-          headers: { Accept: "application/octet-stream" },
-          body: JSON.stringify({ saveDirectory, fileName }),
+        const json_data = await api.post("/getfile", {
+          saveDirectory,
+          fileName,
         });
 
-        if (!response.ok) {
-          // 401 is already reported and logged out by apiFetch.
-          if (response.status !== 401) {
-            const text = await response.json().catch(() => response.statusText);
-            setSnack(`Failed to download file: ${text.message}`, "error");
-            addNotification(
-              `Failed to download file: ${text.message}`,
-              "error",
-            );
-          }
-          return;
-        }
-
-        // Now the backend sends a json response with the signed
-        const data = await response.text();
-        const json_data = JSON.parse(data);
         if (json_data.status === "success" && json_data.signedUrlId) {
           const downloadUrl = new URL(assetBase + "/getfile");
           downloadUrl.searchParams.append("fileId", json_data.signedUrlId);
@@ -315,14 +292,16 @@ function SubList({
           );
         }
       } catch (error) {
-        setSnack(`Error downloading file: ${error.message}`, "error");
+        // A dead session has already been reported once, by apiFetch.
+        if (error.sessionExpired) return;
+        setSnack(`Failed to download file: ${error.message}`, "error");
         addNotification(
-          `Error downloading file ${fileName}: ${error.message}`,
+          `Failed to download ${fileName}: ${error.message}`,
           "error",
         );
       }
     },
-    [apiFetch, setSnack, addNotification],
+    [api, setSnack, addNotification],
   );
 
   /**
@@ -345,27 +324,23 @@ function SubList({
     deleteVideosInDB,
   ) => {
     setSnack(`Deleting: ${videoUrl}`, "info");
-    const response = await apiFetch("/delsub", {
-      method: "post",
-      body: JSON.stringify({
+    try {
+      await api.post("/delsub", {
         playListUrl: playListUrl,
         mappingIds: mappingId ? [mappingId] : [],
         videoUrls: mappingId ? [] : [videoUrl],
         cleanUp: cleanUp,
         deleteVideoMappings: deleteVideoMappings,
         deleteVideosInDB: deleteVideosInDB,
-      }),
-    });
-    if (response.ok) {
+      });
+
       setSnack("Video deleted successfully.", "success");
       addNotification(`Deleted ${title ? title : videoUrl}`, "info");
-      //console.log(`Deleted: ${videoUrl}`);
       setReFetch(
         "delete-sublist-item" + playListUrl + videoUrl + Date.now().toString(),
       );
       setSubListIndex(start); // Reset to start index after deletion
-    }
-    if (!response.ok) {
+    } catch (_error) {
       setSnack(`Failed to delete: ${title ? title : videoUrl}`, "error");
       addNotification(`Failed to delete: ${title ? title : videoUrl}`, "error");
     }
@@ -396,36 +371,35 @@ function SubList({
     //console.log("Fetching items with params: ", { start, stop, sort, query, url: loadedPlayList });
 
     try {
-      const response = await apiFetch("/getsub", {
-        method: "post",
-        signal: controller.signal,
-        body: JSON.stringify({
+      const json_data = await api.post(
+        "/getsub",
+        {
           start,
           stop,
           sortDownloaded: sort,
           query,
           url: loadedPlayList,
-        }),
-      });
+        },
+        { signal: controller.signal },
+      );
 
       if (controller.signal.aborted) return; // Don't update state if component unmounted
 
-      if (response.ok) {
-        const data = await response.text();
-        const json_data = JSON.parse(data);
-        setItems(json_data["rows"]);
-        setPlaylistDirectory(json_data["saveDirectory"]);
-        setPlaylistTitle(json_data["playlistTitle"] || "");
-        setItemCount(parseInt(json_data["count"]));
-      } else {
-        // 401 is already reported and logged out by apiFetch.
+      setItems(json_data["rows"]);
+      setPlaylistDirectory(json_data["saveDirectory"]);
+      setPlaylistTitle(json_data["playlistTitle"] || "");
+      setItemCount(parseInt(json_data["count"]));
+    } catch (error) {
+      if (error instanceof ApiError && !controller.signal.aborted) {
+        // The table is the only place there is to say this, so the refusal is
+        // rendered as the one row it can show.
         setItems([
           {
             positionInPlaylist: 1,
             id: "error-row",
             playlistUrl: loadedPlayList,
             video_metadatum: {
-              title: `Error in fetching sub-lists: ${response.status} ${response.statusText}`,
+              title: `Error in fetching sub-lists: ${error.status} ${error.message}`,
               videoId: "",
               videoUrl: "",
               downloadStatus: false,
@@ -435,10 +409,8 @@ function SubList({
         ]);
         setItemCount(1);
       }
-    } catch (_error) {
-      if (!controller.signal.aborted) {
-        //console.error("Fetch error:", error);
-      }
+      // Anything else -- an abort, or the network -- leaves the table showing
+      // what it already had.
     }
   };
   // useEffects  to load items
@@ -454,7 +426,7 @@ function SubList({
     fetchData(abortController);
     return () => abortController.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiFetch, start, stop, sort, query, loadedPlayList, reFetch]);
+  }, [api, start, stop, sort, query, loadedPlayList, reFetch]);
 
   // Responsive card media height using MUI breakpoints
   const theme = useTheme();
@@ -490,36 +462,29 @@ function SubList({
       setThumbUrls((prev) => ({ ...prev, ...newThumbUrls }));
 
       try {
-        const response = await apiFetch("/getfiles", {
-          method: "post",
-          body: JSON.stringify({ files: filesToFetch }),
-        });
+        const data = await api.post("/getfiles", { files: filesToFetch });
 
-        if (response.ok) {
-          const data = await response.json();
-          if (data.status === "success" && data.files) {
-            const updates = {};
-            Object.entries(data.files).forEach(([fileName, fileData]) => {
-              if (fileData?.signedUrlId) {
-                Reflect.set(
-                  updates,
-                  fileName,
-                  assetBase + "/getfile?fileId=" + fileData.signedUrlId,
-                );
-                Reflect.set(thumbMetaRef.current, fileName, {
-                  fileId: fileData.signedUrlId,
-                  expiry: fileData.expiry,
-                });
-              } else {
-                Reflect.set(updates, fileName, null);
-                Reflect.deleteProperty(thumbMetaRef.current, fileName);
-              }
-            });
-            setThumbUrls((prev) => ({ ...prev, ...updates }));
-            scheduleThumbnailRefresh();
-          }
+        if (data.status === "success" && data.files) {
+          const updates = {};
+          Object.entries(data.files).forEach(([fileName, fileData]) => {
+            if (fileData?.signedUrlId) {
+              Reflect.set(
+                updates,
+                fileName,
+                assetBase + "/getfile?fileId=" + fileData.signedUrlId,
+              );
+              Reflect.set(thumbMetaRef.current, fileName, {
+                fileId: fileData.signedUrlId,
+                expiry: fileData.expiry,
+              });
+            } else {
+              Reflect.set(updates, fileName, null);
+              Reflect.deleteProperty(thumbMetaRef.current, fileName);
+            }
+          });
+          setThumbUrls((prev) => ({ ...prev, ...updates }));
+          scheduleThumbnailRefresh();
         }
-        // 401 is already reported and logged out by apiFetch.
       } catch (_error) {
         //console.error("Error fetching thumbnails:", error);
       }
@@ -527,7 +492,7 @@ function SubList({
 
     fetchThumbnails();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items, playlistDirectory, apiFetch]);
+  }, [items, playlistDirectory, api]);
 
   useEffect(() => {
     if (downloadedItem.url !== null) {

--- a/src/components/VideoPlayer.jsx
+++ b/src/components/VideoPlayer.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 
-import { useApi } from "../hooks/useApi.js";
+import { useApiClient } from "../hooks/useApiClient.js";
 import { assetBase } from "../config.js";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -128,7 +128,7 @@ export default function VideoPlayer({
   loadedPlayList,
   rowsPerPage = 8,
 }) {
-  const apiFetch = useApi();
+  const api = useApiClient();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [videoUrl, setVideoUrl] = useState(null);
@@ -183,7 +183,6 @@ export default function VideoPlayer({
   const abortControllerRef = useRef(null);
   const isMountedRef = useRef(false);
   const playerSessionRef = useRef(0);
-
 
   const clearRefreshTimer = useCallback(() => {
     if (timerRef.current) {
@@ -297,18 +296,14 @@ export default function VideoPlayer({
           videoRef.current.pause();
         }
       }
-      const response = await apiFetch("/getfile", {
-        method: "post",
-        signal: controller.signal,
-        body: JSON.stringify({ saveDirectory, fileName }),
-      });
+      // A refusal throws with the server's own message, which is what the
+      // player surfaces to the viewer.
+      const data = await api.post(
+        "/getfile",
+        { saveDirectory, fileName },
+        { signal: controller.signal },
+      );
 
-      if (!response.ok) {
-        const text = await response.json().catch(() => response.statusText);
-        throw new Error(text?.message || response.statusText);
-      }
-
-      const data = await response.json();
       if (!isMountedRef.current || playerSessionRef.current !== sessionId) {
         return;
       }
@@ -367,19 +362,11 @@ export default function VideoPlayer({
       if (!subtitleFileName) return;
 
       try {
-        const response = await apiFetch("/getfile", {
-          method: "post",
-          body: JSON.stringify({
-            saveDirectory: subtitleSaveDirectory,
-            fileName: subtitleFileName,
-          }),
+        const data = await api.post("/getfile", {
+          saveDirectory: subtitleSaveDirectory,
+          fileName: subtitleFileName,
         });
 
-        if (!response.ok) {
-          throw new Error("Failed to get subtitle URL");
-        }
-
-        const data = await response.json();
         if (
           !isMountedRef.current ||
           playerSessionRef.current !== sessionId ||
@@ -415,7 +402,7 @@ export default function VideoPlayer({
         }
       }
     },
-    [apiFetch, clearSubtitleObjectUrl],
+    [api, clearSubtitleObjectUrl],
   );
 
   const scheduleRefresh = useCallback(
@@ -440,22 +427,18 @@ export default function VideoPlayer({
           return;
         }
         try {
-          const res = await apiFetch("/refreshfile", {
-            method: "POST",
-            body: JSON.stringify({ fileId: scheduledFileId }),
+          const data = await api.post("/refreshfile", {
+            fileId: scheduledFileId,
           });
 
-          if (res.ok) {
-            const data = await res.json();
-            if (
-              data.status === "success" &&
-              isMountedRef.current &&
-              playerSessionRef.current === scheduledSessionId &&
-              fileIdRef.current === scheduledFileId
-            ) {
-              expiryRef.current = data.expiry;
-              scheduleRefresh(scheduledFileId, scheduledSessionId, data.expiry);
-            }
+          if (
+            data.status === "success" &&
+            isMountedRef.current &&
+            playerSessionRef.current === scheduledSessionId &&
+            fileIdRef.current === scheduledFileId
+          ) {
+            expiryRef.current = data.expiry;
+            scheduleRefresh(scheduledFileId, scheduledSessionId, data.expiry);
           }
         } catch (err) {
           if (
@@ -467,7 +450,7 @@ export default function VideoPlayer({
         }
       }, refreshTime);
     },
-    [apiFetch, clearRefreshTimer],
+    [api, clearRefreshTimer],
   );
 
   // Keep refs in sync so setTimeout callbacks always read latest values
@@ -1190,7 +1173,9 @@ export default function VideoPlayer({
               size="small"
               onClick={handleVolumeButtonClick}
               sx={{ color: "white" }}
-              aria-label={isMuted || volume === 0 ? "unmute volume" : "mute volume"}
+              aria-label={
+                isMuted || volume === 0 ? "unmute volume" : "mute volume"
+              }
             >
               {isMuted || volume === 0 ? <VolumeOffIcon /> : <VolumeUpIcon />}
             </IconButton>
@@ -1224,7 +1209,9 @@ export default function VideoPlayer({
                 size="small"
                 onClick={toggleSubtitles}
                 disabled={!subtitleUrl}
-                aria-label={subtitlesEnabled ? "disable subtitles" : "enable subtitles"}
+                aria-label={
+                  subtitlesEnabled ? "disable subtitles" : "enable subtitles"
+                }
                 sx={{
                   color: !subtitleUrl
                     ? "rgba(255,255,255,0.2)"

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -11,13 +11,28 @@ export const AuthContext = createContext({
 const TOKEN_KEY = "ytdiff_token";
 const EXPIRY_KEY = "ytdiff_token_expires_at";
 
+/**
+ * Retires the sentinel builds before the provider refactor wrote.
+ *
+ * Those builds recorded an expired session as the *string* `"null"` rather
+ * than removing the key, so every reader had to know about it. Nothing writes
+ * it any more, but a browser that has not loaded a newer build since still
+ * holds one — so it is deleted here rather than guarded against on every read.
+ *
+ * Runs once per provider mount, which is the first moment storage is looked
+ * at. Once a browser has been through it there is nothing left to find, and
+ * the whole function can go.
+ */
+const clearLegacyTokenSentinel = () => {
+  if (localStorage.getItem(TOKEN_KEY) === "null") {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(EXPIRY_KEY);
+  }
+};
+
 const getStoredToken = () => {
-  const stored = localStorage.getItem(TOKEN_KEY);
-  // The `"null"` guard is for tokens written by builds before the provider
-  // refactor, which stored the string instead of removing the key. Nothing
-  // writes it any more; this only has to outlive the browsers still holding
-  // one.
-  return stored && stored !== "null" ? stored : null;
+  clearLegacyTokenSentinel();
+  return localStorage.getItem(TOKEN_KEY) || null;
 };
 
 const getStoredExpiry = () => {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -58,22 +58,25 @@ export const AuthProvider = ({ children }) => {
    * Memoised, because `apiFetch` and every effect that depends on it key off
    * the identity of these functions.
    */
-  const setToken = useCallback((newToken, { persist = true, expiresAt: nextExpiry = null } = {}) => {
-    setTokenState(newToken);
-    setExpiresAt(newToken ? nextExpiry : null);
+  const setToken = useCallback(
+    (newToken, { persist = true, expiresAt: nextExpiry = null } = {}) => {
+      setTokenState(newToken);
+      setExpiresAt(newToken ? nextExpiry : null);
 
-    if (newToken && persist) {
-      localStorage.setItem(TOKEN_KEY, newToken);
-      if (nextExpiry) {
-        localStorage.setItem(EXPIRY_KEY, String(nextExpiry));
+      if (newToken && persist) {
+        localStorage.setItem(TOKEN_KEY, newToken);
+        if (nextExpiry) {
+          localStorage.setItem(EXPIRY_KEY, String(nextExpiry));
+        } else {
+          localStorage.removeItem(EXPIRY_KEY);
+        }
       } else {
+        localStorage.removeItem(TOKEN_KEY);
         localStorage.removeItem(EXPIRY_KEY);
       }
-    } else {
-      localStorage.removeItem(TOKEN_KEY);
-      localStorage.removeItem(EXPIRY_KEY);
-    }
-  }, []);
+    },
+    [],
+  );
 
   const logout = useCallback(() => {
     setToken(null);

--- a/src/contexts/DownloadContext.jsx
+++ b/src/contexts/DownloadContext.jsx
@@ -8,7 +8,7 @@ import {
   useContext,
 } from "react";
 import PropTypes from "prop-types";
-import { useApi } from "../hooks/useApi.js";
+import { useApiClient } from "../hooks/useApiClient.js";
 import { AuthContext } from "./AuthContext";
 import { NotificationContext } from "./NotificationContext";
 
@@ -40,7 +40,7 @@ export const DownloadContext = createContext({
 export const DownloadProvider = ({ children }) => {
   const [activeDownloads, setActiveDownloads] = useState({});
   const [queuedItems, setQueuedItems] = useState({});
-  const apiFetch = useApi();
+  const api = useApiClient();
   const { token } = useContext(AuthContext);
   const { setSnack, notify } = useContext(NotificationContext);
 
@@ -175,14 +175,7 @@ export const DownloadProvider = ({ children }) => {
   const syncQueueFromBackend = useCallback(async () => {
     if (!token) return null;
     try {
-      const response = await apiFetch("/queuestatus", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      if (!response.ok) return null;
-
-      const result = await response.json();
+      const result = await api.post("/queuestatus", {});
       const newActiveDownloads = {};
       const newQueuedItems = {};
 
@@ -206,7 +199,7 @@ export const DownloadProvider = ({ children }) => {
       // Nothing to recover: the next sync or socket frame will correct us.
       return null;
     }
-  }, [apiFetch, token]);
+  }, [api, token]);
 
   // A backgrounded tab misses socket frames, so re-read the snapshot whenever
   // it comes back. Held in a ref so the listener is registered once.
@@ -244,53 +237,31 @@ export const DownloadProvider = ({ children }) => {
       addToDownloadQueue(entries, requestId);
 
       try {
-        const response = await apiFetch("/download", {
-          method: "post",
-          body: JSON.stringify({
-            urlList: urls,
-            playListUrl: entries[0].playlistUrl,
-          }),
+        const result = await api.post("/download", {
+          urlList: urls,
+          playListUrl: entries[0].playlistUrl,
         });
 
-        if (response.ok) {
-          try {
-            const result = await response.json();
-            const acceptedUrls = (result.items || []).map((item) => item.url);
-            rollbackDownloadQueueRequest(requestId, acceptedUrls);
-            setSnack("Initiated download…", "success");
-            return acceptedUrls;
-          } catch (_error) {
-            rollbackDownloadQueueRequest(requestId, []);
-            setSnack("Could not confirm the download queue.", "error");
-            return [];
-          }
-        }
-
-        rollbackDownloadQueueRequest(requestId, []);
-
-        // 401 is already reported and logged out by apiFetch.
-        if (response.status === 429) {
-          notify("Too many downloads requested. Please wait.", "error");
-        } else if (response.status !== 401) {
-          notify(
-            `Failed to queue downloads: ${response.status} ${response.statusText}`,
-            "error",
-          );
-        }
+        const acceptedUrls = (result.items || []).map((item) => item.url);
+        rollbackDownloadQueueRequest(requestId, acceptedUrls);
+        setSnack("Initiated download…", "success");
+        return acceptedUrls;
       } catch (error) {
+        // The optimistic queue entries have to come back off whatever went
+        // wrong -- a refusal, a dead session, or the network.
         rollbackDownloadQueueRequest(requestId, []);
-        notify(`Failed to queue downloads: ${error.message}`, "error");
+
+        if (error.status === 429) {
+          notify("Too many downloads requested. Please wait.", "error");
+        } else if (!error.sessionExpired) {
+          // A dead session has already been reported once, by apiFetch.
+          notify(`Failed to queue downloads: ${error.message}`, "error");
+        }
       }
 
       return [];
     },
-    [
-      apiFetch,
-      addToDownloadQueue,
-      rollbackDownloadQueueRequest,
-      setSnack,
-      notify,
-    ],
+    [api, addToDownloadQueue, rollbackDownloadQueueRequest, setSnack, notify],
   );
 
   const value = useMemo(

--- a/src/hooks/useApiClient.js
+++ b/src/hooks/useApiClient.js
@@ -1,0 +1,20 @@
+import { useContext, useMemo } from "react";
+import { AuthContext } from "../contexts/AuthContext";
+import { createApiClient } from "../api/client.js";
+import { useApi } from "./useApi";
+
+/**
+ * The authenticated API client, bound to the live session.
+ *
+ * Rebuilt whenever `apiFetch` is — which is whenever the token changes — so a
+ * client captured in an effect never posts with a stale credential.
+ */
+export function useApiClient() {
+  const apiFetch = useApi();
+  const { token } = useContext(AuthContext);
+
+  return useMemo(
+    () => createApiClient(apiFetch, Boolean(token)),
+    [apiFetch, token],
+  );
+}

--- a/src/hooks/useLatest.js
+++ b/src/hooks/useLatest.js
@@ -1,0 +1,37 @@
+import { useRef } from "react";
+
+/**
+ * A ref that always holds the newest value it was called with.
+ *
+ * The socket effect registers eighteen handlers once and must never
+ * re-subscribe, because tearing down and rebuilding the listener set on every
+ * state change would drop events in the gap. Handlers registered once close
+ * over the render that registered them, so anything they need to read *now*
+ * has to arrive through a box rather than through the closure — which is what
+ * this is.
+ *
+ * Written during render rather than in an effect, deliberately. An effect
+ * commits after paint, so a handler that fires in between would read the
+ * previous value; assigning here means the ref is current from the moment the
+ * render that produced the value exists. That makes this unsafe under
+ * concurrent rendering's interruptible renders, which is the same trade the
+ * hand-written mirrors made and the reason React 19's `useEffectEvent`
+ * replaces the pattern outright rather than tidying it.
+ *
+ * Read it only from callbacks and effects. Rendering `ref.current` is what
+ * `react-hooks/refs` actually protects against, and nothing here does that —
+ * so the rule is suppressed on the one line, in the one place, rather than at
+ * each of the call sites that used to write their own mirror inline.
+ *
+ * @template T
+ * @param {T} value - The value to keep current.
+ * @returns {{ current: T }} A stable ref holding the latest `value`.
+ */
+export function useLatest(value) {
+  const ref = useRef(value);
+  // The render-phase write is the point of the hook, and nothing reads the ref
+  // during render. See the note above for the trade this makes.
+  // eslint-disable-next-line react-hooks/refs
+  ref.current = value;
+  return ref;
+}

--- a/src/hooks/useTokenRefresh.js
+++ b/src/hooks/useTokenRefresh.js
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useRef } from "react";
 import { AuthContext } from "../contexts/AuthContext";
-import { useApi } from "./useApi.js";
+import { useApiClient } from "./useApiClient.js";
 
 /**
  * The largest delay `setTimeout` accepts — its argument is a signed 32-bit
@@ -31,13 +31,13 @@ const MIN_DELAY_MS = 30 * 1000;
  *   them hard in background tabs, so a tab woken after its timer should have
  *   fired must not wait for a timer that already missed.
  *
- * Renewal runs through `apiFetch`, so a token that died while the machine was
+ * Renewal runs through the API client, so a token that died while the machine was
  * asleep gets the ordinary 401 path — one "Session expired" and a logout —
  * rather than a special case here.
  */
 export function useTokenRefresh() {
   const { token, expiresAt, setToken } = useContext(AuthContext);
-  const apiFetch = useApi();
+  const api = useApiClient();
   const timerRef = useRef(null);
   const inFlightRef = useRef(false);
 
@@ -55,13 +55,7 @@ export function useTokenRefresh() {
       // The body has to be a JSON object, not nothing: the server's
       // `parseRequestJson` rejects an empty body with a 400 before the handler
       // runs. `/isregallowed` takes the same empty `{}` for the same reason.
-      const response = await apiFetch("/refresh", {
-        method: "post",
-        body: JSON.stringify({}),
-      });
-      if (!response.ok) return null;
-
-      const data = await response.json();
+      const data = await api.post("/refresh", {});
       if (!data?.token) return null;
 
       // Renewal never upgrades a memory-only session to a persisted one: if
@@ -71,13 +65,13 @@ export function useTokenRefresh() {
       setToken(data.token, { persist, expiresAt: data.expiresAt ?? null });
       return data.expiresAt ?? null;
     } catch {
-      // Offline, or the server is down. The existing token is still valid for
-      // now; the next trigger tries again.
+      // A refused renewal, or the server is unreachable. The existing token is
+      // still valid for now; the next trigger tries again.
       return null;
     } finally {
       inFlightRef.current = false;
     }
-  }, [apiFetch, setToken]);
+  }, [api, setToken]);
 
   useEffect(() => {
     const clear = () => {

--- a/tests/contextHarness.jsx
+++ b/tests/contextHarness.jsx
@@ -8,6 +8,29 @@ import { SocketContext } from "../src/contexts/SocketContext";
 import { DownloadContext } from "../src/contexts/DownloadContext";
 
 /**
+ * A stand-in for a `fetch` Response, with every reader a real one has.
+ *
+ * Mocks used to be written out by hand per test, each supplying only the
+ * reader the component under test happened to call -- some `json`, some
+ * `text`, and none of them `status`. That made a mock's shape a statement
+ * about the component's internals, so moving a call onto the shared API client
+ * broke tests that were not testing anything about the change.
+ *
+ * @param body - Parsed to JSON for `json()`, serialized for `text()`.
+ * @param init - `ok` defaults to true; `status` follows it unless given.
+ */
+export function mockResponse(body, { ok = true, status, statusText = "" } = {}) {
+  const serialized = JSON.stringify(body ?? null);
+  return {
+    ok,
+    status: status ?? (ok ? 200 : 500),
+    statusText,
+    json: async () => JSON.parse(serialized),
+    text: async () => serialized,
+  };
+}
+
+/**
  * Builds a set of context values with vi.fn() in every slot, so a test can
  * assert on the calls a component makes the way it used to assert on props.
  *

--- a/tests/desktop/App.test.jsx
+++ b/tests/desktop/App.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import App from "../../src/components/App.jsx";
 import AppProviders from "../../src/AppProviders.jsx";
+import { mockResponse } from "../contextHarness.jsx";
 
 // Mock socket.io-client
 vi.mock("socket.io-client", () => {
@@ -45,10 +46,9 @@ describe("App Component (Desktop)", () => {
   });
 
   test("renders Login screen if no token is stored", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ registrationAllowed: true }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(
+      mockResponse({ registrationAllowed: true }),
+    );
 
     render(
       <AppProviders>
@@ -67,14 +67,10 @@ describe("App Component (Desktop)", () => {
     
     // Mount fetch checks
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ queue: [], generation: "gen_1" }), // syncQueueFromBackend
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ count: 0, rows: [] }), // fetchPlaylists in PlayList.jsx
-      });
+      // syncQueueFromBackend
+      .mockResolvedValueOnce(mockResponse({ queue: [], generation: "gen_1" }))
+      // fetchPlaylists in PlayList.jsx
+      .mockResolvedValueOnce(mockResponse({ count: 0, rows: [] }));
 
     render(
       <AppProviders>

--- a/tests/desktop/AppBatchReindex.test.jsx
+++ b/tests/desktop/AppBatchReindex.test.jsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import App from "../../src/components/App.jsx";
 import AppProviders from "../../src/AppProviders.jsx";
 import { NotificationContext } from "../../src/contexts/NotificationContext";
+import { mockResponse } from "../contextHarness.jsx";
 
 // Hoisted so the socket.io mock factory (which vitest lifts above imports) can
 // close over the same object the tests inspect.
@@ -78,11 +79,11 @@ const BATCH_ID = "batch-abc";
 
 const renderApp = async () => {
   localStorage.setItem("ytdiff_token", "stored_mock_token");
-  globalThis.fetch.mockResolvedValue({
-    ok: true,
-    json: async () => ({ queue: [], generation: "gen_1" }),
-    text: async () => JSON.stringify({ count: 0, rows: [] }),
-  });
+  // Two endpoints fire on mount and this stands in for both, so the body
+  // carries what each of them reads.
+  globalThis.fetch.mockResolvedValue(
+    mockResponse({ queue: [], generation: "gen_1", count: 0, rows: [] }),
+  );
 
   render(
     <AppProviders>

--- a/tests/desktop/AuthContext.test.jsx
+++ b/tests/desktop/AuthContext.test.jsx
@@ -44,10 +44,17 @@ describe("AuthContext (Desktop)", () => {
     expect(screen.getByTestId("token")).toHaveTextContent("stored_token");
   });
 
-  test('treats the literal string "null" as no token', () => {
+  test('clears the legacy "null" sentinel instead of reading around it', () => {
+    // Builds before the provider refactor wrote the string on expiry. A
+    // browser still holding one must come up logged out -- and must not still
+    // be holding it afterwards, or every reader has to keep knowing about it.
     localStorage.setItem("ytdiff_token", "null");
+    localStorage.setItem("ytdiff_token_expires_at", "1893456000");
     renderProvider();
+
     expect(screen.getByTestId("token")).toHaveTextContent("none");
+    expect(localStorage.getItem("ytdiff_token")).toBeNull();
+    expect(localStorage.getItem("ytdiff_token_expires_at")).toBeNull();
   });
 
   test("persists the token by default", () => {

--- a/tests/desktop/Login.test.jsx
+++ b/tests/desktop/Login.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import Login from "../../src/components/Login.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("Login Component (Desktop)", () => {
   const defaultProps = {
@@ -28,10 +28,7 @@ describe("Login Component (Desktop)", () => {
   });
 
   test("checks if registration is allowed on mount and renders Sign Up button if true", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ registrationAllowed: true }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ registrationAllowed: true })));
 
     renderLogin();
 
@@ -45,10 +42,7 @@ describe("Login Component (Desktop)", () => {
   });
 
   test("checks if registration is allowed on mount and hides Sign Up button if false", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ registrationAllowed: false }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ registrationAllowed: false })));
 
     renderLogin();
 
@@ -59,10 +53,7 @@ describe("Login Component (Desktop)", () => {
 
   test("shows error snack if username or password is empty on submit", async () => {
     // Mock isregallowed first
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ registrationAllowed: true }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ registrationAllowed: true })));
 
     renderLogin();
 
@@ -77,16 +68,10 @@ describe("Login Component (Desktop)", () => {
 
   test("submits login and does not persist the token without rememberMe", async () => {
     // 1st fetch: reg check on mount
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ registrationAllowed: true }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ registrationAllowed: true })));
 
     // 2nd fetch: login submit
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ token: "mock_token" }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ token: "mock_token" })));
 
     renderLogin();
 
@@ -118,18 +103,12 @@ describe("Login Component (Desktop)", () => {
   });
 
   test("asks for the token to be persisted if rememberMe is checked", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ registrationAllowed: true }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ registrationAllowed: true })));
 
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({
         token: "mock_token_remembered",
         expiresAt: 1893456000,
-      }),
-    });
+      })));
 
     renderLogin();
 

--- a/tests/desktop/Nav.test.jsx
+++ b/tests/desktop/Nav.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import Navigation from "../../src/components/Nav.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("Nav Component (Desktop)", () => {
   const defaultProps = {
@@ -85,10 +85,7 @@ describe("Nav Component (Desktop)", () => {
   });
 
   test("opens batch re-index dialog and submits config settings", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ message: "Batch re-index started successfully" }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ message: "Batch re-index started successfully" })));
 
     renderNav();
 
@@ -112,7 +109,7 @@ describe("Nav Component (Desktop)", () => {
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "http://localhost:8888/ytdiff/reindexall",
       expect.objectContaining({
-        method: "POST",
+        method: "post",
         body: JSON.stringify({
           start: 5,
           stop: 20,

--- a/tests/desktop/PlayList.test.jsx
+++ b/tests/desktop/PlayList.test.jsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import PlayList from "../../src/components/PlayList.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("PlayList Component (Desktop)", () => {
   const mockPlaylists = {
@@ -52,10 +52,7 @@ describe("PlayList Component (Desktop)", () => {
   });
 
   test("fetches and renders playlists on mount", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => JSON.stringify(mockPlaylists),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(mockPlaylists));
 
     renderPlayList();
 
@@ -81,13 +78,7 @@ describe("PlayList Component (Desktop)", () => {
   });
 
   test("opens Add Dialog on clicking FAB, and submits url list", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => JSON.stringify(mockPlaylists),
-    }).mockResolvedValueOnce({
-      ok: true,
-      text: async () => JSON.stringify({ status: "success" }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(mockPlaylists)).mockResolvedValueOnce(mockResponse({ status: "success" }));
 
     renderPlayList();
 
@@ -129,15 +120,8 @@ describe("PlayList Component (Desktop)", () => {
   /** Submits one url and resolves /list with the given backlog figure. */
   const submitWithQueueDepth = async (queueDepthBefore, props) => {
     globalThis.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        text: async () => JSON.stringify(mockPlaylists),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        text: async () =>
-          JSON.stringify({ status: "success", queueDepthBefore }),
-      });
+      .mockResolvedValueOnce(mockResponse(mockPlaylists))
+      .mockResolvedValueOnce(mockResponse({ status: "success", queueDepthBefore }));
 
     renderPlayList(props);
 

--- a/tests/desktop/Signup.test.jsx
+++ b/tests/desktop/Signup.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import Signup from "../../src/components/Signup.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("Signup Component (Desktop)", () => {
   const defaultProps = {
@@ -63,10 +63,7 @@ describe("Signup Component (Desktop)", () => {
   });
 
   test("submits form and toggles component on successful signup", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "success" }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ status: "success" })));
 
     renderSignup();
 
@@ -96,10 +93,7 @@ describe("Signup Component (Desktop)", () => {
   });
 
   test("displays server error message on failed registration", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ message: "Username already exists" }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ message: "Username already exists" }), { ok: false }));
 
     renderSignup();
 

--- a/tests/desktop/SubList.test.jsx
+++ b/tests/desktop/SubList.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import SubList from "../../src/components/SubList.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("SubList Component (Desktop)", () => {
   const mockSubListResponse = {
@@ -72,10 +72,7 @@ describe("SubList Component (Desktop)", () => {
   });
 
   test("fetches and renders sublist items on mount", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => JSON.stringify(mockSubListResponse),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(mockSubListResponse));
 
     renderSubList();
 
@@ -100,10 +97,7 @@ describe("SubList Component (Desktop)", () => {
   });
 
   test("allows selecting items and triggers bulk queue downloads", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => JSON.stringify(mockSubListResponse),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(mockSubListResponse));
 
     renderSubList();
 

--- a/tests/desktop/VideoPlayer.test.jsx
+++ b/tests/desktop/VideoPlayer.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import VideoPlayer from "../../src/components/VideoPlayer.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("VideoPlayer Component (Desktop)", () => {
   const defaultProps = {
@@ -35,23 +35,14 @@ describe("VideoPlayer Component (Desktop)", () => {
       const body = options?.body ? JSON.parse(options.body) : {};
       if (options?.method?.toLowerCase() === "post") {
         if (body.fileName === "video.mp4") {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({ status: "success", signedUrlId: "signed_url_123", expiry: Date.now() + 3600000 }),
-          });
+          return Promise.resolve(mockResponse(({ status: "success", signedUrlId: "signed_url_123", expiry: Date.now() + 3600000 })));
         }
         if (body.fileName === "video.vtt") {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({ status: "success", signedUrlId: "subtitle_url_123" }),
-          });
+          return Promise.resolve(mockResponse(({ status: "success", signedUrlId: "subtitle_url_123" })));
         }
       } else {
         if (url.includes("subtitle_url_123")) {
-          return Promise.resolve({
-            ok: true,
-            text: async () => "WEBVTT\n\n1\n00:00:00.000 --> 00:00:05.000\nHello World",
-          });
+          return Promise.resolve(mockResponse("WEBVTT\n\n1\n00:00:00.000 --> 00:00:05.000\nHello World"));
         }
       }
       return Promise.reject(new Error(`Unhandled mock fetch: ${url}`));
@@ -87,11 +78,7 @@ describe("VideoPlayer Component (Desktop)", () => {
   });
 
   test("displays error message if fetching signed URL fails", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      statusText: "Forbidden",
-      json: async () => ({ message: "Unauthorized access" }),
-    });
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(({ message: "Unauthorized access" }), { ok: false, statusText: "Forbidden" }));
 
     renderWithContexts(<VideoPlayer {...defaultProps} subTitleFile={null} />, {
       contexts,
@@ -103,10 +90,7 @@ describe("VideoPlayer Component (Desktop)", () => {
   });
 
   test("toggles play/pause states on user trigger", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "success", signedUrlId: "signed_url_123", expiry: Date.now() + 3600000 }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ status: "success", signedUrlId: "signed_url_123", expiry: Date.now() + 3600000 })));
 
     renderWithContexts(<VideoPlayer {...defaultProps} subTitleFile={null} />, {
       contexts,
@@ -124,10 +108,7 @@ describe("VideoPlayer Component (Desktop)", () => {
   });
 
   test("toggles mute setting and saves in localStorage", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "success", signedUrlId: "signed_url_123", expiry: Date.now() + 3600000 }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ status: "success", signedUrlId: "signed_url_123", expiry: Date.now() + 3600000 })));
 
     renderWithContexts(<VideoPlayer {...defaultProps} subTitleFile={null} />, {
       contexts,

--- a/tests/desktop/apiClient.test.jsx
+++ b/tests/desktop/apiClient.test.jsx
@@ -1,0 +1,142 @@
+import { describe, test, expect, vi } from "vitest";
+import { ApiError, createApiClient } from "../../src/api/client.js";
+import { mockResponse } from "../contextHarness.jsx";
+
+/** Builds a client over a stubbed transport, exposing what it was called with. */
+function makeClient(response, { hadToken = true } = {}) {
+  const apiFetch = vi.fn().mockResolvedValue(response);
+  return { api: createApiClient(apiFetch, hadToken), apiFetch };
+}
+
+describe("API client", () => {
+  test("posts JSON and returns the parsed body", async () => {
+    const { api, apiFetch } = makeClient(mockResponse({ rows: [1, 2] }));
+
+    const data = await api.post("/getsub", { start: 0 });
+
+    expect(data).toEqual({ rows: [1, 2] });
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/getsub",
+      expect.objectContaining({ method: "post", body: '{"start":0}' }),
+    );
+  });
+
+  test("omits the body entirely when there is none to send", async () => {
+    // Not the same as sending "undefined": the server's parseRequestJson
+    // refuses an unparseable body before the handler runs.
+    const { api, apiFetch } = makeClient(mockResponse({ ok: 1 }));
+
+    await api.post("/queuestatus");
+
+    expect(apiFetch.mock.calls[0][1]).not.toHaveProperty("body");
+  });
+
+  test("passes an abort signal through", async () => {
+    const { api, apiFetch } = makeClient(mockResponse({}));
+    const controller = new AbortController();
+
+    await api.post("/getsub", {}, { signal: controller.signal });
+
+    expect(apiFetch.mock.calls[0][1].signal).toBe(controller.signal);
+  });
+
+  test("throws ApiError carrying the server's own message", async () => {
+    const { api } = makeClient(
+      mockResponse({ status: "error", message: "Playlist not found" }, {
+        ok: false,
+        status: 404,
+      }),
+    );
+
+    // Every caller used to dig this out for itself, each with its own
+    // fallback for when the server did not send one.
+    const error = await api.post("/getsub", {}).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(404);
+    expect(error.message).toBe("Playlist not found");
+  });
+
+  test("reads the older { error } shape too", async () => {
+    const { api } = makeClient(
+      mockResponse({ error: "Video is not indexed" }, { ok: false, status: 404 }),
+    );
+
+    const error = await api.post("/download", {}).catch((e) => e);
+    expect(error.message).toBe("Video is not indexed");
+  });
+
+  test("falls back to the status line when there is no JSON to read", async () => {
+    // A refusal that never reached the app's own error path — a proxy's HTML
+    // 502, say — has nothing else to report.
+    const { api } = makeClient({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      json: async () => {
+        throw new Error("not JSON");
+      },
+    });
+
+    const error = await api.post("/getplay", {}).catch((e) => e);
+    expect(error.message).toBe("Bad Gateway");
+    expect(error.status).toBe(502);
+  });
+
+  test("marks a 401 as an expired session when a token was in play", async () => {
+    // apiFetch has already notified and logged out; a caller that reported
+    // this again would say it twice.
+    const { api } = makeClient(
+      mockResponse({ message: "Token expired" }, { ok: false, status: 401 }),
+      { hadToken: true },
+    );
+
+    const error = await api.post("/getsub", {}).catch((e) => e);
+    expect(error.sessionExpired).toBe(true);
+  });
+
+  test("a 401 with no session is a rejected credential, not an expiry", async () => {
+    // This is /login with a wrong password, which the login form must report.
+    const { api } = makeClient(
+      mockResponse({ message: "Invalid credentials" }, { ok: false, status: 401 }),
+      { hadToken: false },
+    );
+
+    const error = await api.post("/login", {}).catch((e) => e);
+    expect(error.sessionExpired).toBe(false);
+    expect(error.message).toBe("Invalid credentials");
+  });
+
+  test("a body that will not parse is a fault, not an empty answer", async () => {
+    const { api } = makeClient({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    });
+
+    const error = await api.post("/getplay", {}).catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.message).toMatch(/could not read/);
+  });
+
+  test("a transport failure is not an ApiError", async () => {
+    // The distinction every caller branches on: a refusal carries the
+    // server's words, a network failure never reached it.
+    const apiFetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    const api = createApiClient(apiFetch, true);
+
+    const error = await api.post("/getplay", {}).catch((e) => e);
+    expect(error).not.toBeInstanceOf(ApiError);
+    expect(error.message).toBe("Failed to fetch");
+  });
+
+  test("a caller's own headers survive", async () => {
+    const { api, apiFetch } = makeClient(mockResponse({}));
+
+    await api.post("/getfile", {}, { headers: { Accept: "text/plain" } });
+
+    expect(apiFetch.mock.calls[0][1].headers).toEqual({ Accept: "text/plain" });
+  });
+});

--- a/tests/desktop/useLatest.test.jsx
+++ b/tests/desktop/useLatest.test.jsx
@@ -1,0 +1,58 @@
+import React, { useCallback, useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import { useLatest } from "../../src/hooks/useLatest";
+
+/**
+ * Stands in for the socket effect: a callback captured once, then invoked
+ * later. `read` closes over the first render and must still see the newest
+ * value — that is the whole reason the mirrors exist.
+ */
+function Harness() {
+  const [value, setValue] = useState("first");
+  const latest = useLatest(value);
+
+  // Deliberately empty deps: this is the "registered once" case.
+  const read = useCallback(() => latest.current, []);
+  const [seen, setSeen] = useState("");
+
+  return (
+    <div>
+      <span data-testid="seen">{seen || "nothing"}</span>
+      <button onClick={() => setValue("second")}>change</button>
+      <button onClick={() => setSeen(read())}>read</button>
+    </div>
+  );
+}
+
+describe("useLatest (Desktop)", () => {
+  test("a callback captured on first render reads the newest value", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("read"));
+    expect(screen.getByTestId("seen")).toHaveTextContent("first");
+
+    fireEvent.click(screen.getByText("change"));
+    fireEvent.click(screen.getByText("read"));
+    expect(screen.getByTestId("seen")).toHaveTextContent("second");
+  });
+
+  test("the ref identity is stable across renders", () => {
+    // Handlers hold the box, not the value. A new box per render would strand
+    // every handler registered before it on a ref nothing writes to any more.
+    const boxes = [];
+
+    function Identity() {
+      const [n, setN] = useState(0);
+      boxes.push(useLatest(n));
+      return <button onClick={() => setN((prev) => prev + 1)}>bump</button>;
+    }
+
+    render(<Identity />);
+    fireEvent.click(screen.getByText("bump"));
+    fireEvent.click(screen.getByText("bump"));
+
+    expect(boxes.length).toBeGreaterThan(1);
+    expect(boxes.every((box) => box === boxes[0])).toBe(true);
+  });
+});

--- a/tests/desktop/useTokenRefresh.test.jsx
+++ b/tests/desktop/useTokenRefresh.test.jsx
@@ -4,6 +4,7 @@ import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { AuthContext } from "../../src/contexts/AuthContext";
 import { NotificationContext } from "../../src/contexts/NotificationContext";
 import { useTokenRefresh } from "../../src/hooks/useTokenRefresh";
+import { mockResponse } from "../contextHarness.jsx";
 
 function Harness() {
   useTokenRefresh();
@@ -33,7 +34,7 @@ function renderRefresher({ token = "live_token", expiresAt = expiryIn(3600) } = 
 }
 
 function mockRefreshResponse(body, ok = true) {
-  globalThis.fetch.mockResolvedValueOnce({ ok, status: ok ? 200 : 401, json: async () => body });
+  globalThis.fetch.mockResolvedValueOnce(mockResponse(body));
 }
 
 describe("useTokenRefresh (Desktop)", () => {

--- a/tests/mobile/App.test.jsx
+++ b/tests/mobile/App.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import App from "../../src/components/App.jsx";
 import AppProviders from "../../src/AppProviders.jsx";
+import { mockResponse } from "../contextHarness.jsx";
 
 // Mock socket.io-client
 vi.mock("socket.io-client", () => {
@@ -45,10 +46,7 @@ describe("App Component (Mobile)", () => {
   });
 
   test("renders Login page on mobile by default when not authenticated", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ registrationAllowed: true }),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(({ registrationAllowed: true })));
 
     render(
       <AppProviders>

--- a/tests/mobile/PlayList.test.jsx
+++ b/tests/mobile/PlayList.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import PlayList from "../../src/components/PlayList.jsx";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { mockResponse } from "../contextHarness.jsx";
 
 describe("PlayList Component (Mobile)", () => {
   const theme = createTheme();
@@ -49,10 +50,7 @@ describe("PlayList Component (Mobile)", () => {
   });
 
   test("triggers onMobileLoad instead of setPlayListUrl when LOAD button is clicked on mobile", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => JSON.stringify(mockPlaylists),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(mockPlaylists));
 
     render(
       <ThemeProvider theme={theme}>

--- a/tests/mobile/SubList.test.jsx
+++ b/tests/mobile/SubList.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import SubList from "../../src/components/SubList.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("SubList Component (Mobile)", () => {
   const mockSubListResponse = {
@@ -59,10 +59,7 @@ describe("SubList Component (Mobile)", () => {
   });
 
   test("triggers onBack callback when back button is clicked on mobile", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => JSON.stringify(mockSubListResponse),
-    });
+    globalThis.fetch.mockResolvedValueOnce(mockResponse(mockSubListResponse));
 
     renderSubList();
 

--- a/tests/mobile/VideoPlayer.test.jsx
+++ b/tests/mobile/VideoPlayer.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import VideoPlayer from "../../src/components/VideoPlayer.jsx";
-import { makeContexts, renderWithContexts } from "../contextHarness.jsx";
+import { makeContexts, mockResponse, renderWithContexts } from "../contextHarness.jsx";
 
 describe("VideoPlayer Component (Mobile)", () => {
   const defaultProps = {
@@ -35,10 +35,7 @@ describe("VideoPlayer Component (Mobile)", () => {
       const body = options?.body ? JSON.parse(options.body) : {};
       if (options?.method?.toLowerCase() === "post") {
         if (body.fileName === "video.mp4") {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({ status: "success", signedUrlId: "url_123", expiry: Date.now() + 3600000 }),
-          });
+          return Promise.resolve(mockResponse(({ status: "success", signedUrlId: "url_123", expiry: Date.now() + 3600000 })));
         }
       }
       return Promise.reject(new Error(`Unhandled mock fetch: ${url}`));


### PR DESCRIPTION
## Summary

Refactors API request/response handling across the application by introducing a centralized `ApiClient` that encapsulates JSON serialization, error handling, and response parsing. This eliminates duplicated logic spread across 19+ call sites and establishes a single source of truth for how the API is consumed.

## Key Changes

- **New `ApiClient` abstraction** (`src/api/client.js`):
  - `createApiClient()` factory wraps the low-level `apiFetch` transport
  - `post()` method handles JSON serialization, response validation, and error parsing
  - `ApiError` class distinguishes server refusals from network failures
  - Automatically marks 401 responses as `sessionExpired` when a token was in play (vs. rejected credentials on login)

- **New `useApiClient` hook** (`src/hooks/useApiClient.js`):
  - Replaces direct `useApi()` usage in components
  - Memoizes the client to avoid stale credentials in effect closures
  - Rebuilds whenever the token changes

- **Simplified component code**:
  - `SubList`, `PlayList`, `VideoPlayer`, `Login`, `Signup`, `Nav`, `DownloadContext`: replaced manual `response.ok` checks, `.json()` parsing, and error message extraction with `api.post()` calls
  - Removed ~200 lines of boilerplate response handling
  - Consistent error reporting: callers now check `error instanceof ApiError` rather than inspecting response status

- **New `useLatest` hook** (`src/hooks/useLatest.js`):
  - Provides a stable ref that always holds the newest value
  - Solves stale closure problem in socket effect handlers that register once but must read current state
  - Prevents re-subscription on every state change

- **Test infrastructure**:
  - `mockResponse()` helper in `contextHarness.jsx` standardizes mock Response objects across tests
  - New `apiClient.test.jsx` validates the client's error handling, session detection, and JSON parsing
  - New `useLatest.test.jsx` verifies ref stability and value freshness

- **AuthContext cleanup**:
  - Removes inline guard against legacy `"null"` string sentinel on every read
  - Centralizes cleanup in `clearLegacyTokenSentinel()` called once at provider mount

## Notable Implementation Details

- **Error handling strategy**: `ApiError` carries the server's own message (from `{status, message}` or `{error}` shapes) with a fallback to the HTTP status line. Callers no longer need to parse or guess.
- **Session expiry detection**: A 401 is marked `sessionExpired: true` only when `hadToken` is true, preventing false positives on `/login` with wrong credentials.
- **No body optimization**: `post()` omits the `body` field entirely when none is provided, avoiding unparseable empty strings.
- **Abort signal pass-through**: Supports cancellation for long-running requests (e.g., file downloads).
- **Backward compatibility**: `useLatest` writes during render (not in an effect) to ensure handlers see the newest value immediately, matching the hand-written mirrors it replaces.

https://claude.ai/code/session_014Db4bmjFS1ED2DFBx6GDhm