### PR TITLE
Add error boundary and chunk load error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+coverage
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^6.0.4",
+        "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -233,18 +234,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -275,12 +276,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -331,16 +332,26 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1613,9 +1624,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1633,9 +1641,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1653,9 +1658,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1673,9 +1675,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1693,9 +1692,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1713,9 +1709,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2049,17 +2042,48 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2068,13 +2092,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2105,9 +2129,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2118,13 +2142,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2132,14 +2156,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2148,9 +2172,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2158,13 +2182,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2390,6 +2414,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -3878,6 +3931,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4339,6 +4399,45 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -4856,6 +4955,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6459,19 +6599,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6499,12 +6639,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fmt": "prettier --write \"src/**/*.{js,jsx}\"",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -33,6 +34,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^6.0.4",
+    "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -28,6 +28,7 @@ import { AuthContext } from "../contexts/AuthContext";
 import { SocketContext } from "../contexts/SocketContext";
 import { NotificationContext } from "../contexts/NotificationContext";
 import { DownloadContext } from "../contexts/DownloadContext";
+import ErrorBoundary from "./ErrorBoundary.jsx";
 
 const Navigation = lazy(() => import("./Nav.jsx"));
 const PlayList = lazy(() => import("./PlayList.jsx"));
@@ -147,6 +148,26 @@ const Loader = () => (
     <CircularProgress color="secondary" />
   </Grid>
 );
+
+/**
+ * A lazy region: its own error boundary, then its own Suspense.
+ *
+ * `Suspense` catches the wait, not the failure. Every one of these wraps a
+ * dynamic import, and a rejected import is a throw during render — without a
+ * boundary inside it, a chunk that 404s after a deploy takes the whole tree
+ * down instead of the one panel that could not load. The boundary goes outside
+ * `Suspense` because that is where React looks once the lazy promise rejects.
+ */
+const LazyRegion = ({ label, children }) => (
+  <ErrorBoundary compact label={label}>
+    <Suspense fallback={<Loader />}>{children}</Suspense>
+  </ErrorBoundary>
+);
+
+LazyRegion.propTypes = {
+  label: PropTypes.string,
+  children: PropTypes.node,
+};
 
 export default function App() {
   // Auth, transport, messaging and the download queue all live in providers
@@ -815,16 +836,13 @@ export default function App() {
         xs={12}
         sx={{ height: fullHeight, m: 0, p: 0 }}
       >
-        <Suspense fallback={<Loader />}>
+        <LazyRegion label="The sign-in form">
           {showSignUp ? (
-            <Signup
-              height={fullHeight}
-              toggleSignUpComponent={setShowSignUp}
-            />
+            <Signup height={fullHeight} toggleSignUpComponent={setShowSignUp} />
           ) : (
             <Login height={fullHeight} toggleSignUpComponent={setShowSignUp} />
           )}
-        </Suspense>
+        </LazyRegion>
       </Grid>
       {/* right spacer */}
       <Grid
@@ -914,14 +932,14 @@ export default function App() {
         className="mobile-panel mobile-panel-playlist"
         sx={{ display: "flex", flexDirection: "column" }}
       >
-        <Suspense fallback={<Loader />}>
+        <LazyRegion label="The playlist list">
           <PlayList
             {...playListProps}
             isMobile
             onMobileLoad={handleMobileLoadPlaylist}
             mobileAddDialogRef={mobileAddDialogRef}
           />
-        </Suspense>
+        </LazyRegion>
       </Box>
 
       {/* Panel 2: Videos — slides in/out */}
@@ -934,7 +952,7 @@ export default function App() {
             bgcolor: "background.default",
           }}
         >
-          <Suspense fallback={<Loader />}>
+          <LazyRegion label="The video list">
             <SubList
               {...subListProps}
               isMobile
@@ -942,7 +960,7 @@ export default function App() {
               onOpenAddDialog={handleMobileOpenAddDialog}
               activePlaylistTitle={activePlaylistTitle}
             />
-          </Suspense>
+          </LazyRegion>
         </Box>
       )}
     </Box>
@@ -954,14 +972,14 @@ export default function App() {
     return (
       <Grid container spacing={0}>
         <Grid xl={4} lg={4} md={6} sm={12} xs={12} sx={{ height: fullHeight }}>
-          <Suspense fallback={<Loader />}>
+          <LazyRegion label="The playlist list">
             <PlayList {...playListProps} />
-          </Suspense>
+          </LazyRegion>
         </Grid>
         <Grid xl={8} lg={8} md={6} sm={12} xs={12} sx={{ height: fullHeight }}>
-          <Suspense fallback={<Loader />}>
+          <LazyRegion label="The video list">
             <SubList {...subListProps} />
-          </Suspense>
+          </LazyRegion>
         </Grid>
       </Grid>
     );
@@ -980,7 +998,7 @@ export default function App() {
         }}
       >
         {/* nav bar */}
-        <Suspense fallback={<Loader />}>
+        <LazyRegion label="The navigation bar">
           <Box sx={{ position: "sticky", top: 0, left: 0, zIndex: 100 }}>
             <Navigation
               themeSwitcher={themeSwitcher}
@@ -998,7 +1016,7 @@ export default function App() {
               />
             </Box>
           </Box>
-        </Suspense>
+        </LazyRegion>
         {/* main grid */}
         <Paper sx={{ width: "100%", overflow: "hidden", position: "relative" }}>
           {token === null ? renderAuth() : renderMain()}

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,227 @@
+import { Component } from "react";
+import PropTypes from "prop-types";
+import { isChunkLoadError } from "../lib/chunkLoadError.js";
+
+/**
+ * The last line of defence, and deliberately the dumbest component in the tree.
+ *
+ * It imports nothing but React and PropTypes, and styles itself with inline
+ * rules rather than the theme: it has to render when MUI, the theme, or the
+ * chunk holding them is what broke. Anything it depends on is something it
+ * cannot report a failure in.
+ */
+
+const RELOAD_MARKER = "ytdiff_chunk_reload_at";
+
+/**
+ * How recently a reload has to have happened for another one to count as a
+ * loop. A stale-chunk reload fixes itself on the first try, so a second
+ * failure inside this window means the build itself is broken and reloading
+ * again would only spin.
+ */
+const RELOAD_WINDOW_MS = 10000;
+
+/**
+ * Records a reload attempt, and reports whether this one is allowed.
+ *
+ * Storage can throw outright (Safari's private mode, a browser set to block
+ * site data). A boundary that cannot remember whether it already reloaded must
+ * not reload at all, so any failure here means "show the message instead".
+ */
+function claimReload() {
+  try {
+    const last = Number(sessionStorage.getItem(RELOAD_MARKER));
+    if (Number.isFinite(last) && last > 0) {
+      if (Date.now() - last < RELOAD_WINDOW_MS) return false;
+    }
+    sessionStorage.setItem(RELOAD_MARKER, String(Date.now()));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const palette = {
+  surface: "#ffffff",
+  border: "#d7d7db",
+  text: "#1b1b1f",
+  muted: "#5b5b66",
+  accent: "#7c4dff",
+  accentText: "#ffffff",
+};
+
+const styles = {
+  page: {
+    minHeight: "60vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "24px",
+    boxSizing: "border-box",
+  },
+  compact: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "16px",
+    boxSizing: "border-box",
+  },
+  card: {
+    maxWidth: "34rem",
+    width: "100%",
+    background: palette.surface,
+    color: palette.text,
+    border: `1px solid ${palette.border}`,
+    borderRadius: "8px",
+    padding: "24px",
+    fontFamily:
+      "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+    lineHeight: 1.5,
+    textAlign: "left",
+  },
+  heading: {
+    margin: "0 0 8px",
+    fontSize: "1.125rem",
+    fontWeight: 600,
+  },
+  body: {
+    margin: "0 0 16px",
+    color: palette.muted,
+    fontSize: "0.9375rem",
+  },
+  actions: {
+    display: "flex",
+    gap: "8px",
+    flexWrap: "wrap",
+  },
+  button: {
+    font: "inherit",
+    fontSize: "0.875rem",
+    padding: "8px 16px",
+    borderRadius: "4px",
+    border: `1px solid ${palette.accent}`,
+    background: palette.accent,
+    color: palette.accentText,
+    cursor: "pointer",
+  },
+  secondaryButton: {
+    font: "inherit",
+    fontSize: "0.875rem",
+    padding: "8px 16px",
+    borderRadius: "4px",
+    border: `1px solid ${palette.border}`,
+    background: "transparent",
+    color: palette.text,
+    cursor: "pointer",
+  },
+  details: {
+    marginTop: "16px",
+    fontSize: "0.8125rem",
+    color: palette.muted,
+  },
+  pre: {
+    margin: "8px 0 0",
+    padding: "8px",
+    background: "#f4f4f6",
+    borderRadius: "4px",
+    overflowX: "auto",
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    fontSize: "0.75rem",
+  },
+};
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null, reloading: false };
+    this.handleReload = this.handleReload.bind(this);
+    this.handleRetry = this.handleRetry.bind(this);
+  }
+
+  static getDerivedStateFromError(error) {
+    // Pure by contract — the reload decision happens in componentDidCatch.
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Render failed", error, info?.componentStack);
+
+    if (isChunkLoadError(error) && claimReload()) {
+      this.setState({ reloading: true });
+      window.location.reload();
+    }
+  }
+
+  handleReload() {
+    window.location.reload();
+  }
+
+  handleRetry() {
+    this.setState({ error: null, reloading: false });
+  }
+
+  render() {
+    const { error, reloading } = this.state;
+    const { children, compact, label } = this.props;
+
+    if (!error) return children;
+
+    const stale = isChunkLoadError(error);
+
+    if (reloading) {
+      return (
+        <div style={compact ? styles.compact : styles.page}>
+          <div style={styles.card}>
+            <p style={styles.body}>Loading the latest version…</p>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div style={compact ? styles.compact : styles.page}>
+        <div style={styles.card}>
+          <h2 style={styles.heading}>
+            {stale ? "This tab is out of date" : "Something went wrong"}
+          </h2>
+          <p style={styles.body}>
+            {stale
+              ? "yt-diff was updated while this tab was open, so part of it could no longer be loaded. Reloading picks up the new version."
+              : `${label || "yt-diff"} stopped unexpectedly. Reloading usually clears it; if it keeps happening, the details below are worth reporting.`}
+          </p>
+          <div style={styles.actions}>
+            <button
+              type="button"
+              style={styles.button}
+              onClick={this.handleReload}
+            >
+              Reload
+            </button>
+            {compact && !stale && (
+              <button
+                type="button"
+                style={styles.secondaryButton}
+                onClick={this.handleRetry}
+              >
+                Try again
+              </button>
+            )}
+          </div>
+          <details style={styles.details}>
+            <summary>Details</summary>
+            <pre style={styles.pre}>{String(error.message || error)}</pre>
+          </details>
+        </div>
+      </div>
+    );
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node,
+  /** Renders the panel inline, for a boundary around one region rather than the app. */
+  compact: PropTypes.bool,
+  /** Names the region in the message, e.g. "The playlist view". */
+  label: PropTypes.string,
+};

--- a/src/contexts/SocketContext.jsx
+++ b/src/contexts/SocketContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useMemo, useState, useContext } from "react";
+import { createContext, useEffect, useMemo, useState, useContext } from "react";
 import { AuthContext } from "./AuthContext";
 import io from "socket.io-client";
 import PropTypes from "prop-types";
@@ -16,14 +16,36 @@ export const SocketProvider = ({ children }) => {
   const { token } = useContext(AuthContext);
   // Assigned from the backend's "init" frame; the Nav shows it.
   const [connectionId, setConnectionId] = useState("");
+  const [socket, setSocket] = useState(null);
 
-  const socket = useMemo(() => {
-    if (!token) return null;
-    return io(base, {
+  // Opening a connection is a side effect, not a computation. This lived in a
+  // `useMemo` keyed on `token`, which meant logging out only made the memo
+  // return null — the old socket was dropped on the floor with its connection
+  // still open and still authenticated. The server had no reason to close it,
+  // so it survived until its token expired or the process restarted, and every
+  // login/logout cycle leaked one more signed-out session still receiving
+  // events.
+  useEffect(() => {
+    // No token means no connection; the previous effect's cleanup has already
+    // cleared whatever was there.
+    if (!token) return undefined;
+
+    const sock = io(base, {
       path: socketPath,
       auth: { token },
       forceNew: true,
     });
+    // The rule's own carve-out: this effect subscribes to an external system,
+    // and the object children need in order to talk to it only exists once the
+    // effect has run. The cost is one extra render per token change, which is
+    // the price of the cleanup below actually running.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSocket(sock);
+
+    return () => {
+      sock.disconnect();
+      setSocket((current) => (current === sock ? null : current));
+    };
   }, [token]);
 
   const value = useMemo(

--- a/src/lib/chunkLoadError.js
+++ b/src/lib/chunkLoadError.js
@@ -1,0 +1,24 @@
+/**
+ * A dynamic import that could not be fetched.
+ *
+ * Every deploy rehashes the chunk filenames, so a tab left open across one
+ * asks for a file that no longer exists. That is not a bug in the app — it is
+ * a tab running yesterday's index against today's server — and the fix is to
+ * load the new build rather than show the user a stack trace.
+ *
+ * The wording differs per browser, and none of it is standardised, so this
+ * matches on the shapes the three engines actually produce.
+ */
+export function isChunkLoadError(error) {
+  if (!error) return false;
+  if (error.name === "ChunkLoadError") return true;
+
+  const message = String(error.message || error);
+  return (
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message) ||
+    /Unable to preload CSS/i.test(message) ||
+    /'text\/html' is not a valid JavaScript MIME type/i.test(message)
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 
 import AppProviders from "./AppProviders.jsx";
 import App from "./components/App";
+import ErrorBoundary from "./components/ErrorBoundary.jsx";
 
 import "./style.scss";
 
@@ -17,10 +18,14 @@ if (rootElement._reactRootContainer) {
   root = ReactDOM.createRoot(rootElement);
 }
 
+// Outside the providers on purpose: a throw while a context initialises is
+// exactly the case that would otherwise leave a blank <div id="root">.
 root.render(
   <React.StrictMode>
-    <AppProviders>
-      <App />
-    </AppProviders>
+    <ErrorBoundary>
+      <AppProviders>
+        <App />
+      </AppProviders>
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/tests/desktop/App.test.jsx
+++ b/tests/desktop/App.test.jsx
@@ -11,6 +11,8 @@ vi.mock("socket.io-client", () => {
     on: vi.fn(),
     off: vi.fn(),
     emit: vi.fn(),
+    // The provider tears the connection down on token change and unmount.
+    disconnect: vi.fn(),
   };
   return {
     default: vi.fn(() => mockSocket),

--- a/tests/desktop/AppBatchReindex.test.jsx
+++ b/tests/desktop/AppBatchReindex.test.jsx
@@ -9,7 +9,14 @@ import { mockResponse } from "../contextHarness.jsx";
 // Hoisted so the socket.io mock factory (which vitest lifts above imports) can
 // close over the same object the tests inspect.
 const { mockSocket } = vi.hoisted(() => ({
-  mockSocket: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+  // `disconnect` is part of the surface now: the provider closes the
+  // connection on token change and on unmount.
+  mockSocket: {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  },
 }));
 
 vi.mock("socket.io-client", () => ({

--- a/tests/desktop/ErrorBoundary.test.jsx
+++ b/tests/desktop/ErrorBoundary.test.jsx
@@ -1,0 +1,225 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import ErrorBoundary from "../../src/components/ErrorBoundary.jsx";
+import { isChunkLoadError } from "../../src/lib/chunkLoadError.js";
+
+/** Throws on render, which is the only way into a boundary. */
+function Boom({ error }) {
+  throw error;
+}
+
+const chunkError = () =>
+  new TypeError(
+    "Failed to fetch dynamically imported module: https://host/assets/PlayList-a1b2c3.js",
+  );
+
+let reload;
+let consoleError;
+
+/**
+ * React re-throws a caught error so devtools can see it, jsdom turns that into
+ * a window error event, and vitest prints the trace. The boundary catching it
+ * is the thing under test, so the trace is noise.
+ */
+const swallowWindowError = (event) => event.preventDefault();
+
+beforeEach(() => {
+  window.addEventListener("error", swallowWindowError);
+  sessionStorage.clear();
+  reload = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, reload },
+  });
+  // React logs the caught error itself; the boundary logs it again on purpose.
+  // Neither is a test failure, and both are noise here.
+  consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  window.removeEventListener("error", swallowWindowError);
+  consoleError.mockRestore();
+});
+
+describe("isChunkLoadError", () => {
+  test("recognises what each engine calls a failed dynamic import", () => {
+    expect(isChunkLoadError(chunkError())).toBe(true);
+    expect(
+      isChunkLoadError(new Error("error loading dynamically imported module")),
+    ).toBe(true);
+    expect(
+      isChunkLoadError(new Error("Importing a module script failed.")),
+    ).toBe(true);
+    expect(
+      isChunkLoadError(new Error("Unable to preload CSS for /assets/x.css")),
+    ).toBe(true);
+    const named = new Error("boom");
+    named.name = "ChunkLoadError";
+    expect(isChunkLoadError(named)).toBe(true);
+  });
+
+  test("does not swallow ordinary render errors", () => {
+    expect(isChunkLoadError(new TypeError("x is not a function"))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe("ErrorBoundary (Desktop)", () => {
+  test("renders its children when nothing throws", () => {
+    render(
+      <ErrorBoundary>
+        <p>all good</p>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("all good")).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test("a render error leaves a message rather than a blank page", () => {
+    // F2: with no boundary anywhere in the tree, a throw during render
+    // unmounted everything and left an empty <div id="root">.
+    render(
+      <ErrorBoundary>
+        <Boom error={new TypeError("theme.palette is undefined")} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(screen.getByText("theme.palette is undefined")).toBeInTheDocument();
+    // An ordinary bug is not a stale build, so nothing reloads on its own.
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test("names the region it guards", () => {
+    render(
+      <ErrorBoundary compact label="The playlist list">
+        <Boom error={new Error("nope")} />
+      </ErrorBoundary>,
+    );
+    expect(
+      screen.getByText(/The playlist list stopped unexpectedly/),
+    ).toBeInTheDocument();
+  });
+
+  test("the Reload button reloads", () => {
+    render(
+      <ErrorBoundary>
+        <Boom error={new Error("nope")} />
+      </ErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("a compact boundary can retry without reloading the app", () => {
+    function Flaky({ shouldThrow }) {
+      if (shouldThrow) throw new Error("transient");
+      return <p>recovered</p>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary compact label="The video list">
+        <Flaky shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/stopped unexpectedly/)).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary compact label="The video list">
+        <Flaky shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("recovered")).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test("a stale chunk reloads once and says so", () => {
+    // Every deploy rehashes the chunk filenames, so a tab left open across one
+    // requests a file that no longer exists. That is a stale tab, not a bug.
+    render(
+      <ErrorBoundary>
+        <Boom error={chunkError()} />
+      </ErrorBoundary>,
+    );
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Loading the latest version…")).toBeInTheDocument();
+    expect(sessionStorage.getItem("ytdiff_chunk_reload_at")).toBeTruthy();
+  });
+
+  test("a build that is genuinely broken does not loop", () => {
+    // The reload marker survives the reload, so the second failure in a row
+    // gets the message instead of another round trip.
+    const first = render(
+      <ErrorBoundary>
+        <Boom error={chunkError()} />
+      </ErrorBoundary>,
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    render(
+      <ErrorBoundary>
+        <Boom error={chunkError()} />
+      </ErrorBoundary>,
+    );
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("This tab is out of date")).toBeInTheDocument();
+  });
+
+  test("a stale marker from an earlier session does not block a reload", () => {
+    // The guard is against looping now, not against ever reloading again: a
+    // tab open across two deploys has to be able to catch up twice.
+    sessionStorage.setItem(
+      "ytdiff_chunk_reload_at",
+      String(Date.now() - 60 * 60 * 1000),
+    );
+
+    render(
+      <ErrorBoundary>
+        <Boom error={chunkError()} />
+      </ErrorBoundary>,
+    );
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("storage that throws means the message, never a blind reload", () => {
+    const getItem = vi
+      .spyOn(window.sessionStorage, "getItem")
+      .mockImplementation(() => {
+        throw new DOMException("The operation is insecure.", "SecurityError");
+      });
+    try {
+      render(
+        <ErrorBoundary>
+          <Boom error={chunkError()} />
+        </ErrorBoundary>,
+      );
+      expect(reload).not.toHaveBeenCalled();
+      expect(screen.getByText("This tab is out of date")).toBeInTheDocument();
+    } finally {
+      getItem.mockRestore();
+    }
+  });
+
+  test("the fallback pulls in nothing from the app it is reporting on", async () => {
+    // The panel has to render when MUI or the theme is what broke, so it uses
+    // plain elements and inline styles rather than anything from the tree.
+    const source = await import("../../src/components/ErrorBoundary.jsx?raw");
+    const imports = [...source.default.matchAll(/from\s+"([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    expect(imports).toEqual([
+      "react",
+      "prop-types",
+      "../lib/chunkLoadError.js",
+    ]);
+  });
+});

--- a/tests/desktop/SocketContext.test.jsx
+++ b/tests/desktop/SocketContext.test.jsx
@@ -1,0 +1,137 @@
+import React, { useContext } from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+const sockets = [];
+
+vi.mock("socket.io-client", () => ({
+  default: vi.fn((base, options) => {
+    const sock = {
+      base,
+      options,
+      connected: true,
+      disconnect: vi.fn(() => {
+        sock.connected = false;
+        return sock;
+      }),
+      on: vi.fn(),
+      off: vi.fn(),
+      emit: vi.fn(),
+    };
+    sockets.push(sock);
+    return sock;
+  }),
+}));
+
+import {
+  SocketContext,
+  SocketProvider,
+} from "../../src/contexts/SocketContext";
+import { AuthContext } from "../../src/contexts/AuthContext";
+
+/** Surfaces the socket the provider is currently handing out. */
+function Probe() {
+  const { socket } = useContext(SocketContext);
+  return (
+    <span data-testid="socket">
+      {socket === null || socket === undefined
+        ? "none"
+        : String(socket.options.auth.token)}
+    </span>
+  );
+}
+
+/** Drives the provider by the one input it keys on: the auth token. */
+function renderWithToken(token) {
+  const auth = { token, expiresAt: null, setToken: () => {}, logout: () => {} };
+  return render(
+    <AuthContext.Provider value={auth}>
+      <SocketProvider>
+        <Probe />
+      </SocketProvider>
+    </AuthContext.Provider>,
+  );
+}
+
+describe("SocketContext (Desktop)", () => {
+  beforeEach(() => {
+    sockets.length = 0;
+  });
+
+  test("connects once a token is present", () => {
+    renderWithToken("t_one");
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].options.auth).toEqual({ token: "t_one" });
+    expect(screen.getByTestId("socket")).toHaveTextContent("t_one");
+  });
+
+  test("opens no connection without a token", () => {
+    renderWithToken(null);
+    expect(sockets).toHaveLength(0);
+    expect(screen.getByTestId("socket")).toHaveTextContent("none");
+  });
+
+  test("logging out disconnects rather than dropping the socket", () => {
+    // F3: the connection used to be built in a `useMemo`, so `setToken(null)`
+    // only made the memo return null. The socket object was dropped while its
+    // connection stayed open and authenticated — a signed-out session still
+    // receiving events until its token expired, one leaked per logout.
+    const { rerender } = renderWithToken("t_one");
+    const [first] = sockets;
+    expect(first.disconnect).not.toHaveBeenCalled();
+
+    const loggedOut = {
+      token: null,
+      expiresAt: null,
+      setToken: () => {},
+      logout: () => {},
+    };
+    act(() => {
+      rerender(
+        <AuthContext.Provider value={loggedOut}>
+          <SocketProvider>
+            <Probe />
+          </SocketProvider>
+        </AuthContext.Provider>,
+      );
+    });
+
+    expect(first.disconnect).toHaveBeenCalledTimes(1);
+    expect(first.connected).toBe(false);
+    expect(sockets).toHaveLength(1);
+    expect(screen.getByTestId("socket")).toHaveTextContent("none");
+  });
+
+  test("a new token disconnects the old connection before using the new one", () => {
+    const { rerender } = renderWithToken("t_one");
+    const renewed = {
+      token: "t_two",
+      expiresAt: null,
+      setToken: () => {},
+      logout: () => {},
+    };
+    act(() => {
+      rerender(
+        <AuthContext.Provider value={renewed}>
+          <SocketProvider>
+            <Probe />
+          </SocketProvider>
+        </AuthContext.Provider>,
+      );
+    });
+
+    expect(sockets).toHaveLength(2);
+    expect(sockets[0].disconnect).toHaveBeenCalledTimes(1);
+    expect(sockets[1].disconnect).not.toHaveBeenCalled();
+    expect(screen.getByTestId("socket")).toHaveTextContent("t_two");
+  });
+
+  test("unmounting disconnects", () => {
+    const { unmount } = renderWithToken("t_one");
+    const [first] = sockets;
+    act(() => {
+      unmount();
+    });
+    expect(first.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/mobile/App.test.jsx
+++ b/tests/mobile/App.test.jsx
@@ -11,6 +11,8 @@ vi.mock("socket.io-client", () => {
     on: vi.fn(),
     off: vi.fn(),
     emit: vi.fn(),
+    // The provider tears the connection down on token change and unmount.
+    disconnect: vi.fn(),
   };
   return {
     default: vi.fn(() => mockSocket),

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,6 +13,26 @@ export default mergeConfig(
         "tests/desktop/vitest.config.js",
         "tests/mobile/vitest.config.js",
       ],
+      // A floor, not a target: set where coverage already sits so it can only
+      // rise. Nothing hard is carved out — App.jsx and VideoPlayer.jsx are the
+      // two files that most need the gate, and excluding them would leave it
+      // measuring only the easy ones, which is how a coverage gate becomes
+      // decorative. `main.jsx` is the only exclusion: it is the ReactDOM
+      // bootstrap, it has no branches, and there is nothing there to cover.
+      coverage: {
+        provider: "v8",
+        reporter: ["text-summary", "lcov"],
+        reportsDirectory: "coverage",
+        all: true,
+        include: ["src/**/*.{js,jsx}"],
+        exclude: ["src/main.jsx"],
+        thresholds: {
+          statements: 64,
+          branches: 47,
+          functions: 55,
+          lines: 66,
+        },
+      },
     },
   })
 );


### PR DESCRIPTION
## Summary

Adds comprehensive error handling to gracefully recover from stale chunk loads after deployments and render errors. Introduces an `ErrorBoundary` component that detects failed dynamic imports and automatically reloads the page once, while providing user-friendly error messages for other failures.

## Key Changes

- **New `ErrorBoundary` component** (`src/components/ErrorBoundary.jsx`): A minimal, self-contained error boundary that:
  - Renders only with React and PropTypes, using inline styles to work even when MUI or the theme is broken
  - Detects stale chunk loads (failed dynamic imports after deployment) and automatically reloads once
  - Prevents reload loops by tracking reload attempts in sessionStorage with a 10-second window
  - Provides a "Try again" button for compact boundaries around individual regions
  - Shows detailed error messages for debugging

- **New `chunkLoadError` utility** (`src/lib/chunkLoadError.js`): Detects dynamic import failures across browsers (Chrome, Firefox, Safari) with pattern matching for various error message formats

- **Updated `SocketContext`** (`src/contexts/SocketContext.jsx`): Fixed socket connection leak by moving from `useMemo` to `useEffect`:
  - Properly disconnects old socket when token changes or component unmounts
  - Prevents signed-out sessions from remaining authenticated until token expiration

- **Wrapped lazy regions in `App.jsx`**: Created `LazyRegion` component that wraps each dynamic import with both `ErrorBoundary` and `Suspense`, ensuring chunk load failures don't crash the entire app

- **Root-level error boundary** (`src/main.jsx`): Placed outside all providers to catch initialization errors that would otherwise leave a blank page

- **Test coverage**: Added comprehensive tests for `ErrorBoundary` and `SocketContext` with 64%+ statement coverage threshold

- **Build configuration**: Added `test:coverage` npm script and coverage thresholds to `vitest.config.js`

## Implementation Details

- The error boundary uses sessionStorage to track reload attempts, with fallback to showing the error message if storage is unavailable (e.g., Safari private mode)
- Stale chunk errors trigger an automatic reload with a "Loading the latest version…" message; subsequent failures in the same session show the error instead of looping
- The boundary is intentionally "dumb" — it imports nothing from the app tree to ensure it can render even when core dependencies are broken
- Socket cleanup now properly uses effect cleanup functions instead of relying on memo invalidation, fixing a resource leak where disconnected sockets remained authenticated

https://claude.ai/code/session_0153HLAaq2TNBUUkyQaVFLdi