### PR TITLE
Put both lists' pagination in the location

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -231,12 +231,27 @@ export default function App() {
   // thing a link, a bookmark or the Back button has to be able to name. It is
   // read from the router and written through it, so the URL and the view
   // cannot disagree — there is only the one value.
-  const { playlistUrl: playListUrl, videoUrl: routeVideoUrl } = useRoute();
+  const {
+    playlistUrl: playListUrl,
+    videoUrl: routeVideoUrl,
+    playlistPage: routePlaylistPage,
+    playlistPageSize: routePlaylistPageSize,
+    videoPage: routeVideoPage,
+    videoPageSize: routeVideoPageSize,
+  } = useRoute();
   const navigate = useNavigate();
 
-  /** A person clicked something: leave an entry for Back to return to. */
+  /**
+   * A person clicked something: leave an entry for Back to return to.
+   *
+   * Opening a different playlist keeps the page the playlist list is on — you
+   * picked that row *from* page 26, so throwing you back to page 1 would undo
+   * the navigation you just did — but starts the new playlist's videos at
+   * their first page, since a position in the previous playlist means nothing
+   * in this one. The page size carries over, because that is a preference.
+   */
   const setPlayListUrl = useCallback(
-    (url) => navigate({ playlistUrl: url, videoUrl: null }),
+    (url) => navigate({ playlistUrl: url, videoUrl: null, videoPage: 0 }),
     [navigate],
   );
 
@@ -246,20 +261,55 @@ export default function App() {
    * an entry they have to press Back through to leave.
    */
   const replacePlayListUrl = useCallback(
-    (url) => navigate({ playlistUrl: url, videoUrl: null }, { replace: true }),
+    (url) =>
+      navigate(
+        { playlistUrl: url, videoUrl: null, videoPage: 0 },
+        { replace: true },
+      ),
     [navigate],
   );
 
   /** Opens or closes the player, within whatever list is currently open. */
   const setRouteVideoUrl = useCallback(
-    (videoUrl, { replace = false } = {}) =>
-      navigate({ playlistUrl: playListUrl, videoUrl }, { replace }),
-    [navigate, playListUrl],
+    (videoUrl, { replace = false } = {}) => navigate({ videoUrl }, { replace }),
+    [navigate],
   );
 
-  const [subListIndex, setSubListIndex] = useState(0);
+  /**
+   * Records where a list has been paged to.
+   *
+   * Always a replace. Paging is a refinement of the view you are already in,
+   * not somewhere new: if it pushed, Back would walk you through every page
+   * you had turned instead of leaving the playlist, which is the one thing
+   * Back has to keep meaning.
+   */
+  const setPlaylistPagination = useCallback(
+    (page, pageSize) =>
+      navigate(
+        { playlistPage: page, playlistPageSize: pageSize },
+        { replace: true },
+      ),
+    [navigate],
+  );
+
+  const setVideoPagination = useCallback(
+    (page, pageSize) =>
+      navigate({ videoPage: page, videoPageSize: pageSize }, { replace: true }),
+    [navigate],
+  );
+
+  // Both lists page by seeking to an index rather than to a page number, so
+  // the route's page reaches them as the index it names. That is why a link
+  // to page 26 of the playlist list opens on page 26 rather than on page 1:
+  // it feeds the same seek the socket handlers already use, instead of adding
+  // a second way for a list to be told where to go.
+  const [subListIndex, setSubListIndex] = useState(
+    () => routeVideoPage * routeVideoPageSize,
+  );
   // this will be used to seek to the latest playlist
-  const [playListIndex, setPlayListIndex] = useState(0);
+  const [playListIndex, setPlayListIndex] = useState(
+    () => routePlaylistPage * routePlaylistPageSize,
+  );
   const [disableProgress, toggleProgress] = useState(false);
 
   // progress bar and re-fetch state
@@ -270,7 +320,22 @@ export default function App() {
   const [reFetchPlaylist, setReFetchPlaylist] = useState(Date.now().toString());
   const [reFetchSubList, setReFetchSubList] = useState(Date.now().toString());
   // TODO: Add separate reFetch states for playlist and sub-list to avoid unnecessary fetches
-  const [rowsPerPageSubList, setRowsPerPageSubList] = useState(8);
+  const [rowsPerPageSubList, setRowsPerPageSubList] = useState(
+    () => routeVideoPageSize,
+  );
+
+  /**
+   * Changing the page size restarts the list from its first page, so the two
+   * move together — and the location says so, rather than keeping a page
+   * number that the new size has made meaningless.
+   */
+  const handleSetRowsPerPageSubList = useCallback(
+    (size) => {
+      setRowsPerPageSubList(size);
+      setVideoPagination(0, size);
+    },
+    [setVideoPagination],
+  );
 
   // Mobile slide navigation state.
   //
@@ -548,7 +613,10 @@ export default function App() {
     setSubListIndex,
     tableContainerHeight: `${tableContainerHeight}px`,
     rowsPerPageSubList,
-    setRowsPerPageSubList,
+    setRowsPerPageSubList: handleSetRowsPerPageSubList,
+    initialPage: routePlaylistPage,
+    initialRowsPerPage: routePlaylistPageSize,
+    onPaginationChange: setPlaylistPagination,
   };
 
   const subListProps = {
@@ -561,9 +629,11 @@ export default function App() {
     setReFetch: setReFetchSubList,
     tableContainerHeight: `${tableContainerHeight}px`,
     rowsPerPage: rowsPerPageSubList,
-    setRowsPerPage: setRowsPerPageSubList,
+    setRowsPerPage: handleSetRowsPerPageSubList,
     playerVideoUrl: routeVideoUrl,
     setPlayerVideoUrl: setRouteVideoUrl,
+    initialPage: routeVideoPage,
+    onPaginationChange: setVideoPagination,
   };
 
   // renders mobile main with slide navigation

--- a/src/components/PlayList.jsx
+++ b/src/components/PlayList.jsx
@@ -44,6 +44,7 @@ import { useDependencyLogger } from "../hooks/useDependencyLogger.js";
 import { NotificationContext } from "../contexts/NotificationContext";
 import { ApiError } from "../api/client.js";
 import { useApiClient } from "../hooks/useApiClient.js";
+import { DEFAULT_PLAYLIST_PAGE_SIZE } from "../router/routes.js";
 import TablePaginationActions from "./Pagination.jsx";
 import PlayListItemRow from "./PlayListItemRow.jsx";
 
@@ -67,6 +68,14 @@ const options = [
   ["Delete everything", true, true, true, "everything", "error"],
 ];
 
+/**
+ * The default `onPaginationChange`. A module constant so the default keeps a
+ * stable identity across renders and does not churn the callbacks built on it.
+ *
+ * @type {(page: number, pageSize: number) => void}
+ */
+const NO_REPORT = () => {};
+
 function PlayList({
   setPlayListUrl,
   playListUrl,
@@ -78,6 +87,12 @@ function PlayList({
   setRowsPerPageSubList,
   playListIndex,
   setPlayListIndex,
+  // Where the location says this list is paged to, read once to start from.
+  // After that the list owns its own page and reports it back through
+  // `onPaginationChange`; the location follows the list, not the reverse.
+  initialPage = 0,
+  initialRowsPerPage = DEFAULT_PLAYLIST_PAGE_SIZE,
+  onPaginationChange = NO_REPORT,
   // Mobile props (optional — only passed on mobile)
   isMobile,
   onMobileLoad,
@@ -93,10 +108,15 @@ function PlayList({
   const [order, updateOrder] = useState("1");
   // These are the controls
   const [localQuery, setLocalQuery] = useState("");
-  const [start, setStart] = useState(0);
-  const [stop, setStop] = useState(10);
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
+  // Seeded from the location so the very first fetch asks for the page the
+  // link named. Deriving it later instead would spend a request on page 1 and
+  // then throw those rows away.
+  const [start, setStart] = useState(() => initialPage * initialRowsPerPage);
+  const [stop, setStop] = useState(
+    () => (initialPage + 1) * initialRowsPerPage,
+  );
+  const [page, setPage] = useState(() => initialPage);
+  const [rowsPerPage, setRowsPerPage] = useState(() => initialRowsPerPage);
   // actual table data
   const [items, setItems] = useState([]);
   const [totalItems, setTotalItems] = useState(0);
@@ -340,14 +360,17 @@ function PlayList({
       setPage(validPage);
       setStart(validPage * rowsPerPage);
       setStop((validPage + 1) * rowsPerPage);
+      onPaginationChange(validPage, rowsPerPage);
     },
-    [rowsPerPage, setStart, setStop, setPage],
+    [rowsPerPage, setStart, setStop, setPage, onPaginationChange],
   );
 
   const handleChangeRowsPerPage = (event) => {
-    setStop(start + +event.target.value);
-    setRowsPerPage(+event.target.value);
+    const size = +event.target.value;
+    setStop(start + size);
+    setRowsPerPage(size);
     setPage(0);
+    onPaginationChange(0, size);
   };
 
   const handleLoad = (url, title) => {
@@ -379,6 +402,11 @@ function PlayList({
   // from App, which means setting state from an effect. Untangling it belongs
   // with the PlayList decomposition, not here.
   useEffect(() => {
+    // Nothing has loaded yet: the seek below would compute a page from a count
+    // of zero and reset to page 1, undoing the page the location asked for
+    // before the rows that justify it have arrived.
+    if (totalItems === 0) return;
+
     if (playListIndex === -1) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       handleChangePage(null, 0); // Reset to the first page if playListIndex is -1
@@ -823,6 +851,9 @@ PlayList.propTypes = {
   rowsPerPageSubList: PropTypes.number.isRequired,
   setRowsPerPageSubList: PropTypes.func.isRequired,
   playListIndex: PropTypes.number.isRequired,
+  initialPage: PropTypes.number,
+  initialRowsPerPage: PropTypes.number,
+  onPaginationChange: PropTypes.func,
   setPlayListIndex: PropTypes.func.isRequired,
   // Mobile props
   isMobile: PropTypes.bool,

--- a/src/components/SubList.jsx
+++ b/src/components/SubList.jsx
@@ -54,6 +54,13 @@ import VideoPlayer from "./VideoPlayer.jsx";
  */
 const NO_ROUTER = () => {};
 
+/**
+ * The default `onPaginationChange`, a module constant for the same reason.
+ *
+ * @type {(page: number, pageSize: number) => void}
+ */
+const NO_REPORT = () => {};
+
 function SubList({
   setPlayListUrl,
   loadedPlayList,
@@ -69,6 +76,11 @@ function SubList({
   // router still plays videos, it just does not put them in the address bar.
   playerVideoUrl = null,
   setPlayerVideoUrl = NO_ROUTER,
+  // Where the location says this list is paged to, read once to start from.
+  // After that the list owns its page and reports it back; the location
+  // follows the list, not the reverse.
+  initialPage = 0,
+  onPaginationChange = NO_REPORT,
   // Mobile props (optional — only passed on mobile)
   isMobile,
   onBack,
@@ -85,9 +97,11 @@ function SubList({
   const [sort, updateSort] = useState(false);
   // These are the controls
   const [localQuery, setLocalQuery] = useState("");
-  const [start, setStart] = useState(0);
-  const [stop, setStop] = useState(8);
-  const [page, setPage] = useState(0);
+  // Seeded from the location so the first fetch asks for the page the link
+  // named, rather than spending a request on page 1 and discarding it.
+  const [start, setStart] = useState(() => initialPage * rowsPerPage);
+  const [stop, setStop] = useState(() => (initialPage + 1) * rowsPerPage);
+  const [page, setPage] = useState(() => initialPage);
   // actual table data
   const { items, setItems, itemCount, playlistDirectory, playlistTitle } =
     useSubListRows({
@@ -151,8 +165,9 @@ function SubList({
       setPage(validPage);
       setStart(validPage * rowsPerPage);
       setStop((validPage + 1) * rowsPerPage);
+      onPaginationChange(validPage, rowsPerPage);
     },
-    [rowsPerPage, setPage, setStart, setStop],
+    [rowsPerPage, setPage, setStart, setStop, onPaginationChange],
   );
 
   const handleChangeRowsPerPage = (event) => {
@@ -497,6 +512,10 @@ function SubList({
   };
 
   useEffect(() => {
+    // Before any rows have arrived the seek below has nothing to measure
+    // against, and would reset to page 1 the page the location asked for.
+    if (itemCount === 0) return;
+
     if (subListIndex === -1) {
       // Reset to the first page if subListIndex is -1
       // eslint-disable-next-line react-hooks/set-state-in-effect -- the page state exists to follow this prop; there is no derived form of "which page shows position N"
@@ -835,6 +854,8 @@ SubList.propTypes = {
   setRowsPerPage: PropTypes.func.isRequired,
   playerVideoUrl: PropTypes.string,
   setPlayerVideoUrl: PropTypes.func,
+  initialPage: PropTypes.number,
+  onPaginationChange: PropTypes.func,
   // Mobile props
   isMobile: PropTypes.bool,
   onBack: PropTypes.func,

--- a/src/router/RouterProvider.jsx
+++ b/src/router/RouterProvider.jsx
@@ -84,18 +84,24 @@ export function RouterProvider({ children }) {
   const route = useMemo(() => parseRoute(hash), [hash]);
 
   /**
-   * Goes to `next`.
+   * Goes to the location `patch` describes, merged over the one we are on.
    *
-   * `replace` is not a detail: an auto-navigation the user did not ask for —
-   * a background listing finishing and pulling the view to its playlist — must
-   * not leave a history entry they have to press Back through to escape. Those
-   * call sites replace; everything a person clicks pushes.
+   * A patch rather than a whole route, and merged against the location read
+   * back *now* rather than against a render's snapshot. Two navigations in one
+   * event handler are ordinary here — clearing the list moves the playlist and
+   * resets the video page — and against a snapshot the second would carry the
+   * first's stale fields back into the URL, undoing it.
    *
-   * @param {import("./routes.js").Route} next
+   * `replace` is not a detail either: an auto-navigation the user did not ask
+   * for — a background listing finishing and pulling the view to its playlist
+   * — must not leave a history entry they have to press Back through to
+   * escape. Those call sites replace; everything a person clicks pushes.
+   *
+   * @param {Partial<import("./routes.js").Route>} patch
    * @param {{replace?: boolean}} [options]
    */
-  const navigate = useCallback((next, { replace = false } = {}) => {
-    const target = formatRoute(next);
+  const navigate = useCallback((patch, { replace = false } = {}) => {
+    const target = formatRoute({ ...parseRoute(readHash()), ...patch });
     const history = globalThis.history;
 
     // Re-navigating to where we already are must never add an entry.
@@ -137,7 +143,10 @@ export function useRoute() {
 /**
  * The navigate function. A no-op without a provider, for the same reason.
  *
- * @returns {(next: import("./routes.js").Route, options?: {replace?: boolean}) => void}
+ * It takes a patch, not a whole route: callers say what changes and the rest
+ * is read off the location as it stands. See `navigate` for why that matters.
+ *
+ * @returns {(patch: Partial<import("./routes.js").Route>, options?: {replace?: boolean}) => void}
  */
 export function useNavigate() {
   const context = useContext(RouterContext);

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -17,6 +17,8 @@
  *   #/unlisted                the videos that belong to no playlist
  *   #/playlist/<encoded url>  one playlist
  *   ...?v=<encoded url>       the player, open on one video
+ *   ...?pp=26&ps=10           which page of the playlist list, and its size
+ *   ...?vp=4&vs=8             which page of the video list, and its size
  *
  * Playlist and video URLs are the primary keys the backend already uses
  * (`PlaylistMetadata.playlistUrl`, `VideoMetadata.videoUrl`), so they go in
@@ -24,6 +26,13 @@
  * short id column and a lookup endpoint, which is a migration; this format
  * costs nothing to ship and can be redirected from later if anyone turns out
  * to share these links.
+ *
+ * **Pagination is in the URL because resuming needs it.** Opening a link to a
+ * playlist that sits on page 26 of the list, or to page 4 of its videos, has
+ * to put both panels where they were — otherwise "resume" means the right
+ * panel is right and the left panel is on page 1. Page numbers are written
+ * 1-based because that is what the pagination controls display; everything
+ * inside the app counts pages from zero.
  */
 
 /** No playlist selected. The value the app has always used for this. */
@@ -32,20 +41,41 @@ export const NO_PLAYLIST = "init";
 /** The pseudo-playlist holding videos that belong to no playlist. */
 export const UNLISTED = "None";
 
+/**
+ * Page sizes the two lists start on. They are the grammar's defaults as well
+ * as the components' initial state, so a location that says nothing about
+ * pagination and a location that spells out the defaults mean the same thing —
+ * and only the first is ever written.
+ */
+export const DEFAULT_PLAYLIST_PAGE_SIZE = 10;
+export const DEFAULT_VIDEO_PAGE_SIZE = 8;
+
 const PLAYLIST_SEGMENT = "playlist";
 const UNLISTED_SEGMENT = "unlisted";
 const VIDEO_PARAM = "v";
+const PLAYLIST_PAGE_PARAM = "pp";
+const PLAYLIST_SIZE_PARAM = "ps";
+const VIDEO_PAGE_PARAM = "vp";
+const VIDEO_SIZE_PARAM = "vs";
 
 /**
  * @typedef {Object} Route
  * @property {string} playlistUrl - `NO_PLAYLIST`, `UNLISTED`, or a playlist URL.
  * @property {?string} videoUrl - The video the player is open on, or null.
+ * @property {number} playlistPage - Zero-based page of the playlist list.
+ * @property {number} playlistPageSize - Rows per page in the playlist list.
+ * @property {number} videoPage - Zero-based page of the video list.
+ * @property {number} videoPageSize - Rows per page in the video list.
  */
 
 /** Where an empty, unrecognised or malformed location lands. */
 export const ROOT_ROUTE = Object.freeze({
   playlistUrl: NO_PLAYLIST,
   videoUrl: null,
+  playlistPage: 0,
+  playlistPageSize: DEFAULT_PLAYLIST_PAGE_SIZE,
+  videoPage: 0,
+  videoPageSize: DEFAULT_VIDEO_PAGE_SIZE,
 });
 
 /** `decodeURIComponent` throws on a lone `%`; a bad link is not a crash. */
@@ -64,10 +94,34 @@ function splitQuery(location) {
   return [location.slice(0, at), location.slice(at + 1)];
 }
 
-function readVideoParam(search) {
-  if (!search) return null;
-  const value = new URLSearchParams(search).get(VIDEO_PARAM);
-  return value ? value : null;
+/**
+ * Reads a positive integer parameter, falling back to `fallback`.
+ *
+ * Hand-edited and rotted links reach this: `?vp=0`, `?vp=-3`, `?vp=abc` and a
+ * missing parameter all mean the same thing, which is "the app decides".
+ */
+function readCount(params, name, fallback) {
+  const raw = params.get(name);
+  if (raw === null) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) return fallback;
+  return value;
+}
+
+/** Reads the pagination half of a location's query string. */
+function readPagination(search) {
+  const params = new URLSearchParams(search);
+  return {
+    // 1-based in the URL, zero-based everywhere inside the app.
+    playlistPage: readCount(params, PLAYLIST_PAGE_PARAM, 1) - 1,
+    playlistPageSize: readCount(
+      params,
+      PLAYLIST_SIZE_PARAM,
+      DEFAULT_PLAYLIST_PAGE_SIZE,
+    ),
+    videoPage: readCount(params, VIDEO_PAGE_PARAM, 1) - 1,
+    videoPageSize: readCount(params, VIDEO_SIZE_PARAM, DEFAULT_VIDEO_PAGE_SIZE),
+  };
 }
 
 /**
@@ -83,31 +137,47 @@ export function parseRoute(hash) {
   const raw = typeof hash === "string" ? hash : "";
   const [path, search] = splitQuery(raw.startsWith("#") ? raw.slice(1) : raw);
   const segments = path.split("/").filter(Boolean);
-  const videoUrl = readVideoParam(search);
+  const params = new URLSearchParams(search);
+  const videoUrl = params.get(VIDEO_PARAM) || null;
+  const pagination = readPagination(search);
+
+  // The playlist list is on screen at every location, so where it is paged to
+  // survives even a location that names no playlist.
+  const listOnly = {
+    ...ROOT_ROUTE,
+    playlistPage: pagination.playlistPage,
+    playlistPageSize: pagination.playlistPageSize,
+  };
 
   if (segments.length === 0) {
-    // A video with no list to play it from is not a location the app can show.
-    return { ...ROOT_ROUTE };
+    // A video with no list to play it from is not a location the app can show,
+    // and neither is a page of a video list that is not open.
+    return listOnly;
   }
 
   if (segments.length === 1 && segments[0] === UNLISTED_SEGMENT) {
-    return { playlistUrl: UNLISTED, videoUrl };
+    return { ...pagination, playlistUrl: UNLISTED, videoUrl };
   }
 
   if (segments.length === 2 && segments[0] === PLAYLIST_SEGMENT) {
     const playlistUrl = decodeSegment(segments[1]);
     // A hand-written `#/playlist/None` means the unlisted view; `#/playlist/init`
     // means nothing selected. Normalising here keeps parse(format(x)) total.
-    if (playlistUrl === UNLISTED) return { playlistUrl: UNLISTED, videoUrl };
-    if (playlistUrl === NO_PLAYLIST || !playlistUrl) return { ...ROOT_ROUTE };
-    return { playlistUrl, videoUrl };
+    if (playlistUrl === UNLISTED) {
+      return { ...pagination, playlistUrl: UNLISTED, videoUrl };
+    }
+    if (playlistUrl === NO_PLAYLIST || !playlistUrl) return listOnly;
+    return { ...pagination, playlistUrl, videoUrl };
   }
 
-  return { ...ROOT_ROUTE };
+  return listOnly;
 }
 
 /**
  * Writes a route back out as a location fragment, always with a leading `#`.
+ *
+ * Only what differs from the default is written, so the common case stays a
+ * short link and `parse(format(x))` still round-trips.
  *
  * @param {?Route} route
  * @returns {string}
@@ -123,13 +193,33 @@ export function formatRoute(route) {
     path = `/${PLAYLIST_SEGMENT}/${encodeURIComponent(playlistUrl)}`;
   }
 
+  const params = new URLSearchParams();
+
   // The player is always opened from a row of some list, so a video outside
   // one is dropped rather than written to a location that cannot be parsed back.
-  if (videoUrl && path !== "/") {
-    const params = new URLSearchParams();
-    params.set(VIDEO_PARAM, videoUrl);
-    return `#${path}?${params.toString()}`;
+  const listIsOpen = path !== "/";
+  if (videoUrl && listIsOpen) params.set(VIDEO_PARAM, videoUrl);
+
+  const playlistPage = route?.playlistPage ?? 0;
+  const playlistPageSize =
+    route?.playlistPageSize ?? DEFAULT_PLAYLIST_PAGE_SIZE;
+  if (playlistPage > 0) {
+    params.set(PLAYLIST_PAGE_PARAM, String(playlistPage + 1));
+  }
+  if (playlistPageSize !== DEFAULT_PLAYLIST_PAGE_SIZE) {
+    params.set(PLAYLIST_SIZE_PARAM, String(playlistPageSize));
   }
 
-  return `#${path}`;
+  // A page of the video list means nothing when no video list is open.
+  if (listIsOpen) {
+    const videoPage = route?.videoPage ?? 0;
+    const videoPageSize = route?.videoPageSize ?? DEFAULT_VIDEO_PAGE_SIZE;
+    if (videoPage > 0) params.set(VIDEO_PAGE_PARAM, String(videoPage + 1));
+    if (videoPageSize !== DEFAULT_VIDEO_PAGE_SIZE) {
+      params.set(VIDEO_SIZE_PARAM, String(videoPageSize));
+    }
+  }
+
+  const search = params.toString();
+  return search ? `#${path}?${search}` : `#${path}`;
 }

--- a/tests/desktop/AppRouting.test.jsx
+++ b/tests/desktop/AppRouting.test.jsx
@@ -31,18 +31,46 @@ vi.mock("../../src/components/Nav.jsx", () => ({
 // Surfaces the playlist it was handed, and offers a way to select one, so the
 // tests can drive selection the way a click does.
 vi.mock("../../src/components/PlayList.jsx", () => ({
-  default: ({ playListUrl, setPlayListUrl }) => (
+  default: ({
+    playListUrl,
+    setPlayListUrl,
+    initialPage,
+    initialRowsPerPage,
+    playListIndex,
+    onPaginationChange,
+  }) => (
     <div data-testid="mock-playlist">
       {`current:${playListUrl}`}
+      <span data-testid="pl-seed">
+        {`page:${initialPage} size:${initialRowsPerPage} index:${playListIndex}`}
+      </span>
       <button onClick={() => setPlayListUrl("https://yt/list?list=PL1")}>
         open PL1
+      </button>
+      <button onClick={() => setPlayListUrl("https://yt/list?list=PL2")}>
+        open PL2
+      </button>
+      <button onClick={() => onPaginationChange(25, 10)}>
+        playlists page 26
       </button>
     </div>
   ),
 }));
 vi.mock("../../src/components/SubList.jsx", () => ({
-  default: ({ loadedPlayList }) => (
-    <div data-testid="mock-sublist">{`loaded:${loadedPlayList}`}</div>
+  default: ({
+    loadedPlayList,
+    initialPage,
+    rowsPerPage,
+    subListIndex,
+    onPaginationChange,
+  }) => (
+    <div data-testid="mock-sublist">
+      {`loaded:${loadedPlayList}`}
+      <span data-testid="sub-seed">
+        {`page:${initialPage} size:${rowsPerPage} index:${subListIndex}`}
+      </span>
+      <button onClick={() => onPaginationChange(3, 8)}>videos page 4</button>
+    </div>
   ),
 }));
 vi.mock("../../src/components/Login.jsx", () => ({
@@ -71,6 +99,8 @@ const click = async (name) => {
 };
 
 const current = () => screen.getByTestId("mock-playlist").textContent;
+const playlistSeed = () => screen.getByTestId("pl-seed").textContent;
+const videoSeed = () => screen.getByTestId("sub-seed").textContent;
 
 const renderApp = async () => {
   localStorage.setItem("ytdiff_token", "stored_mock_token");
@@ -159,5 +189,69 @@ describe("App — routing (Desktop)", () => {
 
     expect(current()).toContain("current:https://yt/list?list=PLauto");
     expect(globalThis.history.length).toBe(before);
+  });
+
+  describe("pagination in the location", () => {
+    test("a link to a playlist on page 26 opens the list on page 26", async () => {
+      // The bug this covers: the right panel honoured the link and the left
+      // panel stayed on page 1, so "resume" only half worked.
+      globalThis.history.replaceState(
+        null,
+        "",
+        "#/playlist/" +
+          encodeURIComponent("https://yt/list?list=PL1") +
+          "?pp=26",
+      );
+      await renderApp();
+
+      // Seeded as a page for the first fetch, and as the index the existing
+      // seek already understands: 25 * 10.
+      expect(playlistSeed()).toBe("page:25 size:10 index:250");
+    });
+
+    test("a link carries the video page and page size too", async () => {
+      globalThis.history.replaceState(null, "", "#/unlisted?vp=4&vs=32");
+      await renderApp();
+
+      expect(videoSeed()).toBe("page:3 size:32 index:96");
+    });
+
+    test("paging records where you are without stacking history", async () => {
+      // Paging replaces rather than pushes: Back has to keep meaning "leave
+      // this playlist", not "undo the last page turn".
+      await renderApp();
+      await click("open PL1");
+      const afterOpen = globalThis.history.length;
+
+      await click("videos page 4");
+
+      expect(globalThis.location.hash).toContain("vp=4");
+      expect(globalThis.history.length).toBe(afterOpen);
+    });
+
+    test("the playlist list keeps its page when a playlist is opened", async () => {
+      // You picked that row from page 26; snapping the list back to page 1
+      // would undo the navigation you just made.
+      await renderApp();
+      await click("playlists page 26");
+      expect(globalThis.location.hash).toContain("pp=26");
+
+      await click("open PL1");
+
+      expect(globalThis.location.hash).toContain("pp=26");
+      expect(current()).toContain("current:https://yt/list?list=PL1");
+    });
+
+    test("opening another playlist starts its videos at page 1", async () => {
+      // A position in the previous playlist means nothing in this one.
+      await renderApp();
+      await click("open PL1");
+      await click("videos page 4");
+      expect(globalThis.location.hash).toContain("vp=4");
+
+      await click("open PL2");
+
+      expect(globalThis.location.hash).not.toContain("vp=");
+    });
   });
 });

--- a/tests/desktop/RouterProvider.test.jsx
+++ b/tests/desktop/RouterProvider.test.jsx
@@ -30,6 +30,16 @@ function Probe() {
       >
         replace
       </button>
+      {/* Two navigations in one handler, the shape `clearList` has: leave the
+          playlist, then reset the video page. */}
+      <button
+        onClick={() => {
+          navigate({ playlistUrl: NO_PLAYLIST, videoUrl: null });
+          navigate({ videoPage: 0 }, { replace: true });
+        }}
+      >
+        clear then reset
+      </button>
     </div>
   );
 }
@@ -109,5 +119,23 @@ describe("RouterProvider", () => {
     render(<Probe />);
     expect(screen.getByTestId("playlist").textContent).toBe(NO_PLAYLIST);
     expect(() => screen.getByText("push").click()).not.toThrow();
+  });
+
+  test("a second navigation in one handler does not undo the first", async () => {
+    // Both calls happen before React re-renders, so a `navigate` that merged
+    // against a render's snapshot would carry the playlist the first call just
+    // cleared back into the URL. It merges against the live location instead.
+    globalThis.history.replaceState(
+      null,
+      "",
+      "#/playlist/" + encodeURIComponent(PLAYLIST) + "?vp=4",
+    );
+    renderProbe();
+    expect(playlist()).toBe(PLAYLIST);
+
+    await click("clear then reset");
+
+    expect(playlist()).toBe(NO_PLAYLIST);
+    expect(globalThis.location.hash).toBe("#/");
   });
 });

--- a/tests/desktop/routes.test.js
+++ b/tests/desktop/routes.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  DEFAULT_PLAYLIST_PAGE_SIZE,
+  DEFAULT_VIDEO_PAGE_SIZE,
   formatRoute,
   NO_PLAYLIST,
   parseRoute,
@@ -10,36 +12,39 @@ import {
 const PLAYLIST = "https://www.youtube.com/playlist?list=PLabc123";
 const VIDEO = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=1s";
 
+/** A full route, so a test only has to name the fields it is about. */
+const route = (partial) => ({
+  playlistUrl: NO_PLAYLIST,
+  videoUrl: null,
+  playlistPage: 0,
+  playlistPageSize: DEFAULT_PLAYLIST_PAGE_SIZE,
+  videoPage: 0,
+  videoPageSize: DEFAULT_VIDEO_PAGE_SIZE,
+  ...partial,
+});
+
 describe("the URL grammar", () => {
   test("an empty or bare location is 'nothing selected'", () => {
     for (const location of ["", "#", "#/", undefined, null]) {
-      expect(parseRoute(location)).toEqual({
-        playlistUrl: NO_PLAYLIST,
-        videoUrl: null,
-      });
+      expect(parseRoute(location)).toEqual(route({}));
     }
   });
 
   test("a playlist URL survives its own query string", () => {
     // The reason the whole URL is percent-encoded into one segment: it carries
     // a `?list=` of its own, which would otherwise be read as the route's.
-    const route = parseRoute(formatRoute({ playlistUrl: PLAYLIST }));
-    expect(route.playlistUrl).toBe(PLAYLIST);
+    const parsed = parseRoute(formatRoute(route({ playlistUrl: PLAYLIST })));
+    expect(parsed.playlistUrl).toBe(PLAYLIST);
   });
 
   test("a playlist and a video round-trip together", () => {
-    const original = { playlistUrl: PLAYLIST, videoUrl: VIDEO };
+    const original = route({ playlistUrl: PLAYLIST, videoUrl: VIDEO });
     expect(parseRoute(formatRoute(original))).toEqual(original);
   });
 
   test("the unlisted view has its own name rather than a sentinel", () => {
-    expect(formatRoute({ playlistUrl: UNLISTED, videoUrl: null })).toBe(
-      "#/unlisted",
-    );
-    expect(parseRoute("#/unlisted")).toEqual({
-      playlistUrl: UNLISTED,
-      videoUrl: null,
-    });
+    expect(formatRoute(route({ playlistUrl: UNLISTED }))).toBe("#/unlisted");
+    expect(parseRoute("#/unlisted")).toEqual(route({ playlistUrl: UNLISTED }));
   });
 
   test("the sentinels are not reachable as literal playlist names", () => {
@@ -54,33 +59,101 @@ describe("the URL grammar", () => {
     // A lone `%` makes decodeURIComponent throw; unknown shapes are simply
     // not routes. Neither is allowed to be a crash.
     for (const location of ["#/playlist/%E0%A4%A", "#/nope/deeper", "#/x"]) {
-      expect(parseRoute(location)).toEqual({
-        playlistUrl: NO_PLAYLIST,
-        videoUrl: null,
-      });
+      expect(parseRoute(location)).toEqual(route({}));
     }
   });
 
   test("a video outside any list is dropped in both directions", () => {
     // The player is always opened from a row of some list, so there is no
     // location that means "this video, from nowhere".
-    expect(formatRoute({ playlistUrl: NO_PLAYLIST, videoUrl: VIDEO })).toBe(
-      "#/",
-    );
+    expect(formatRoute(route({ videoUrl: VIDEO }))).toBe("#/");
     expect(parseRoute("#/?v=" + encodeURIComponent(VIDEO)).videoUrl).toBeNull();
+  });
+
+  describe("pagination", () => {
+    test("page numbers are 1-based in the URL and 0-based inside", () => {
+      // The controls display page 26; the app counts it as 25. The URL matches
+      // what the person reading it can see on screen.
+      const link = formatRoute(
+        route({ playlistUrl: PLAYLIST, playlistPage: 25, videoPage: 3 }),
+      );
+      expect(link).toContain("pp=26");
+      expect(link).toContain("vp=4");
+
+      const parsed = parseRoute(link);
+      expect(parsed.playlistPage).toBe(25);
+      expect(parsed.videoPage).toBe(3);
+    });
+
+    test("defaults are left out, so an ordinary link stays short", () => {
+      expect(formatRoute(route({ playlistUrl: UNLISTED }))).toBe("#/unlisted");
+    });
+
+    test("page sizes are written only when they differ from the default", () => {
+      const link = formatRoute(
+        route({
+          playlistUrl: PLAYLIST,
+          playlistPageSize: 25,
+          videoPageSize: 32,
+        }),
+      );
+      expect(link).toContain("ps=25");
+      expect(link).toContain("vs=32");
+      expect(parseRoute(link).playlistPageSize).toBe(25);
+      expect(parseRoute(link).videoPageSize).toBe(32);
+    });
+
+    test("where the playlist list is paged to survives at the root", () => {
+      // The left panel is on screen at every location, so its page is not
+      // something only a playlist link can carry.
+      const link = formatRoute(route({ playlistPage: 25 }));
+      expect(link).toBe("#/?pp=26");
+      expect(parseRoute(link).playlistPage).toBe(25);
+    });
+
+    test("a video page means nothing with no video list open", () => {
+      expect(formatRoute(route({ videoPage: 3, videoPageSize: 32 }))).toBe(
+        "#/",
+      );
+      expect(parseRoute("#/?vp=4&vs=32").videoPage).toBe(0);
+      expect(parseRoute("#/?vp=4&vs=32").videoPageSize).toBe(
+        DEFAULT_VIDEO_PAGE_SIZE,
+      );
+    });
+
+    test("a hand-mangled page number falls back rather than breaking", () => {
+      // `0` and negatives are not pages anyone can be on, and `abc` is not a
+      // number; all of them mean "the app decides".
+      const parsed = parseRoute("#/unlisted?pp=0&vp=-3&ps=abc&vs=");
+      expect(parsed).toEqual(route({ playlistUrl: UNLISTED }));
+    });
+
+    test("a fractional page is not a page", () => {
+      expect(parseRoute("#/unlisted?vp=2.5").videoPage).toBe(0);
+    });
   });
 
   test("format always produces something parse accepts", () => {
     const routes = [
-      { playlistUrl: NO_PLAYLIST, videoUrl: null },
-      { playlistUrl: UNLISTED, videoUrl: null },
-      { playlistUrl: UNLISTED, videoUrl: VIDEO },
-      { playlistUrl: PLAYLIST, videoUrl: null },
-      { playlistUrl: PLAYLIST, videoUrl: VIDEO },
-      { playlistUrl: "https://x.com/a b/c#frag", videoUrl: "a&b=c" },
+      route({}),
+      route({ playlistUrl: UNLISTED }),
+      route({ playlistUrl: UNLISTED, videoUrl: VIDEO }),
+      route({ playlistUrl: PLAYLIST }),
+      route({ playlistUrl: PLAYLIST, videoUrl: VIDEO }),
+      route({ playlistUrl: PLAYLIST, playlistPage: 25, videoPage: 3 }),
+      route({
+        playlistUrl: PLAYLIST,
+        videoUrl: VIDEO,
+        playlistPage: 7,
+        playlistPageSize: 50,
+        videoPage: 2,
+        videoPageSize: 64,
+      }),
+      route({ playlistPage: 12 }),
+      route({ playlistUrl: "https://x.com/a b/c#frag", videoUrl: "a&b=c" }),
     ];
-    for (const route of routes) {
-      expect(parseRoute(formatRoute(route))).toEqual(route);
+    for (const original of routes) {
+      expect(parseRoute(formatRoute(original))).toEqual(original);
     }
   });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -28,8 +28,8 @@ export default mergeConfig(
         exclude: ["src/main.jsx"],
         thresholds: {
           statements: 72,
-          branches: 55,
-          functions: 62,
+          branches: 56,
+          functions: 63,
           lines: 73,
         },
       },


### PR DESCRIPTION
## Summary

Follow-up to #93, from using the merged routing. Two gaps, which turn out to be the same missing thing.

**A link only moved one panel.** A link naming a playlist put the video list on it and left the playlist list on page 1 — so a playlist sitting on page 26 of 26 was open on the right and nowhere to be seen on the left.

**Where a list was paged to was not in the location at all**, so a reload or a bookmark lost it even when the playlist survived.

## Changes

- **`src/router/routes.js`** — the grammar gains four optional parameters: `pp`/`ps` for the playlist list, `vp`/`vs` for the video list. Pages are 1-based in the URL because that is what the pagination controls display; inside the app they stay 0-based. Only non-defaults are written, so an ordinary link is unchanged. A video page is dropped when no video list is open, the same rule `?v=` already followed.

- **`src/router/RouterProvider.jsx`** — `navigate` now takes a *patch* and merges it against the location read back at call time, rather than taking a whole route.

- **`src/components/App.jsx`** — the route's pages seed `playListIndex` and `subListIndex`, and the page sizes seed the lists' initial state. Pagination changes are reported back through two callbacks.

- **`src/components/PlayList.jsx` / `src/components/SubList.jsx`** — each takes its starting page from the location, reports page and size changes back, and no longer runs its seek against an empty list.

## Implementation details

- **Reusing the seek, not adding a second path.** Both lists already page by converting an *index* into a page — that is how the socket handlers move them. The location's page reaches them as the index it names, so there is one way for a list to be told where to go rather than two. The page also seeds each list's initial state, so the first fetch asks for the right page instead of spending a request on page 1 and discarding it.

- **Paging replaces rather than pushes.** It is a refinement of the view you are already in, not somewhere new: if it pushed, Back would walk you through every page you turned instead of leaving the playlist, which is the one thing Back has to keep meaning.

- **Opening a playlist keeps the playlist list's page.** You picked that row *from* page 26, so snapping the list back to page 1 would undo the navigation you just made. Only the video page resets, because a position in the previous playlist means nothing in this one; the page size carries across, being a preference rather than a position. The `checkJs` gate caught this.

- **Two navigations in one handler no longer undo each other.** `clearList` leaves the playlist and then resets the video page, and both run before React re-renders — so merging a patch against a render's snapshot carried the playlist the first call had just cleared back into the URL. Hence the patch-and-merge contract above. Covered by a test that fails against the previous behaviour.

## Known limit

This makes *resuming* work — a reload, a bookmark, your own back-navigation. A link someone shares that carries no `pp` still opens the playlist list on page 1, because locating an arbitrary playlist's page needs the server to say what index it sits at under the current sort and filter. That is a small endpoint if shared links should auto-locate; it is not in this change.

## Verification

Lint, `typecheck`, and `build` all clean; suite 180 → 193 with coverage up on every axis and the F10 floor raised to match (72/56/63/73).

https://claude.ai/code/session_01W37SLdAnU6r72izdFGB9Aq

---
_Generated by [Claude Code](https://claude.ai/code/session_01W37SLdAnU6r72izdFGB9Aq)_